### PR TITLE
Frontend support for favorites

### DIFF
--- a/frontend/src/app/favorites/page.tsx
+++ b/frontend/src/app/favorites/page.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import { Metadata } from 'next';
+import defaultImage from '@/assets/placeholder_cover_img.jpeg';
+import FavoriteTable from '@/features/favorites/Favorites';
+import { unstable_cache } from 'next/cache';
+import { fetchAllVendors } from '@/features/directory/api/fetchVendors';
+
+export const metadata: Metadata = {
+  title: "Favorite Artists - Asian Wedding Hair & Makeup in NYC, LA & more",
+  description: "Browse your favorite wedding vendors from our directory of hair and makeup artists experienced with Asian features.",
+  openGraph: {
+    title: 'Favorite Artists — Asian Wedding Hair & Makeup in NYC, LA & more',
+    description: 'Browse your favorite wedding vendors from our directory of hair and makeup artists experienced with Asian features.',
+    url: 'https://www.asianweddingmakeup.com/favorites',
+    type: 'website',
+    siteName: 'Asian Wedding Hair & Makeup',
+    images: [
+      {
+        url: defaultImage.src,
+        width: 1200,
+        height: 630,
+        alt: 'Wedding Vendor Directory Preview',
+      },
+    ],
+  },
+  alternates: {
+    canonical: "https://www.asianweddingmakeup.com/favorites",
+  },
+};
+const getCachedVendors = unstable_cache(fetchAllVendors);
+
+
+export default async function Favorites() {
+  const vendors = await getCachedVendors();
+
+  return (
+    <Container maxWidth="lg">
+      <br />
+      <Box
+        sx={{
+          my: 4,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          textAlign: 'left',
+          '& > p': { marginBottom: 2 },
+        }}
+      >
+        <Typography variant="h1" component="h1" gutterBottom>
+          My Favorites
+        </Typography>
+        {process.env.NODE_ENV === 'development' && (<FavoriteTable favoriteVendors={vendors}/>
+        )}
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/src/app/favorites/page.tsx
+++ b/frontend/src/app/favorites/page.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import { Metadata } from 'next';
 import defaultImage from '@/assets/placeholder_cover_img.jpeg';
-import FavoriteTable from '@/features/favorites/Favorites';
+import FavoriteTable from '@/features/favorites/FavoriteTable';
 import { unstable_cache } from 'next/cache';
 import { fetchAllVendors } from '@/features/directory/api/fetchVendors';
 

--- a/frontend/src/app/favorites/page.tsx
+++ b/frontend/src/app/favorites/page.tsx
@@ -52,8 +52,10 @@ export default async function Favorites() {
         <Typography variant="h1" component="h1" gutterBottom>
           My Favorites
         </Typography>
-        {process.env.NODE_ENV === 'development' && (<FavoriteTable favoriteVendors={vendors}/>
-        )}
+        {process.env.NODE_ENV === 'development'
+          ? (<FavoriteTable favoriteVendors={vendors} />)
+          : <Typography variant="h4">Coming soon...</Typography>
+        }
       </Box>
     </Container>
   );

--- a/frontend/src/features/business/components/VendorDetails.tsx
+++ b/frontend/src/features/business/components/VendorDetails.tsx
@@ -16,6 +16,7 @@ import {
 import { Public, LocationOn, Mail, Link, Instagram, Place } from '@mui/icons-material';
 import { Vendor } from '@/types/vendor';
 import Grid from '@mui/system/Grid';
+import FavoriteIcon from '@mui/icons-material/Favorite';
 
 const StickyCard = styled(Card)(({ theme }) => ({
   position: 'sticky',
@@ -24,13 +25,17 @@ const StickyCard = styled(Card)(({ theme }) => ({
 
 interface VendorDetailsProps {
   vendor: Vendor;
+  isFavorite?: boolean;
 }
 
 const DEFAULT_PRICE = "Contact for Pricing";
 
-export function VendorDetails({ vendor }: VendorDetailsProps) {
+export function VendorDetails({ vendor, isFavorite }: VendorDetailsProps) {
   const theme = useTheme();
-
+  const handleFavoriteClick = () => {
+    // Add code here to save the vendor to favorites
+  };
+  isFavorite = true;
   return (
     <Box>
       <Container maxWidth="lg" sx={{ py: 8 }}>
@@ -58,7 +63,11 @@ export function VendorDetails({ vendor }: VendorDetailsProps) {
           {/* Vendor Info */}
           <Grid size={{ xs: 12, md: 7 }}>
             <Typography variant="h2" component="h1" sx={{ fontFamily: 'serif', mb: 2 }}>
-              {vendor.business_name}
+              {vendor.business_name} {isFavorite ? (
+              <FavoriteIcon
+                color='primary'
+              />
+              ) : null}
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -73,7 +82,6 @@ export function VendorDetails({ vendor }: VendorDetailsProps) {
                 />
               )}
             </Box>
-
             <Box
               sx={{
                 pt: 3,
@@ -272,7 +280,7 @@ export function VendorDetails({ vendor }: VendorDetailsProps) {
                     mb: 3,
                     textAlign: 'center'
                   }}>
-                    Get in Touch
+                    Love what you see?
                   </Typography>
                   <Button
                     variant="contained"
@@ -283,6 +291,16 @@ export function VendorDetails({ vendor }: VendorDetailsProps) {
                     href={`mailto:${vendor.email}`}
                   >
                     Contact Vendor
+                  </Button>
+                  <Button
+                    variant="contained"
+                    size="large"
+                    fullWidth
+                    startIcon={<FavoriteIcon />}
+                    sx={{ mb: 3 }}
+                    onClick={handleFavoriteClick}
+                  >
+                    {isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}
                   </Button>
                 </CardContent>
               </StickyCard>

--- a/frontend/src/features/business/components/VendorDetails.tsx
+++ b/frontend/src/features/business/components/VendorDetails.tsx
@@ -280,7 +280,7 @@ export function VendorDetails({ vendor, isFavorite }: VendorDetailsProps) {
                     mb: 3,
                     textAlign: 'center'
                   }}>
-                    Love what you see?
+                    {process.env.NODE_ENV === 'development' ? 'Love what you see?' : 'Get in Touch'}
                   </Typography>
                   <Button
                     variant="contained"

--- a/frontend/src/features/business/components/VendorDetails.tsx
+++ b/frontend/src/features/business/components/VendorDetails.tsx
@@ -35,7 +35,7 @@ export function VendorDetails({ vendor, isFavorite }: VendorDetailsProps) {
   const handleFavoriteClick = () => {
     // Add code here to save the vendor to favorites
   };
-  isFavorite = true;
+  isFavorite = true; // Todo: make this dynamic
   return (
     <Box>
       <Container maxWidth="lg" sx={{ py: 8 }}>
@@ -63,10 +63,10 @@ export function VendorDetails({ vendor, isFavorite }: VendorDetailsProps) {
           {/* Vendor Info */}
           <Grid size={{ xs: 12, md: 7 }}>
             <Typography variant="h2" component="h1" sx={{ fontFamily: 'serif', mb: 2 }}>
-              {vendor.business_name} {isFavorite ? (
-              <FavoriteIcon
-                color='primary'
-              />
+              {vendor.business_name} {process.env.NODE_ENV === 'development' && isFavorite ? (
+                <FavoriteIcon
+                  color='primary'
+                />
               ) : null}
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
@@ -292,16 +292,18 @@ export function VendorDetails({ vendor, isFavorite }: VendorDetailsProps) {
                   >
                     Contact Vendor
                   </Button>
-                  <Button
-                    variant="contained"
-                    size="large"
-                    fullWidth
-                    startIcon={<FavoriteIcon />}
-                    sx={{ mb: 3 }}
-                    onClick={handleFavoriteClick}
-                  >
-                    {isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}
-                  </Button>
+                  {process.env.NODE_ENV === 'development' && (
+                    <Button
+                      variant="contained"
+                      size="large"
+                      fullWidth
+                      startIcon={<FavoriteIcon />}
+                      sx={{ mb: 3 }}
+                      onClick={handleFavoriteClick}
+                    >
+                      {isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}
+                    </Button>
+                  )}
                 </CardContent>
               </StickyCard>
             </Grid>

--- a/frontend/src/features/directory/components/VendorCard.tsx
+++ b/frontend/src/features/directory/components/VendorCard.tsx
@@ -9,7 +9,7 @@ import LocationOnIconOutlined from '@mui/icons-material/LocationOnOutlined';
 import PublicIcon from '@mui/icons-material/Public';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
-import { useTheme } from '@mui/material';
+import { IconButton, useTheme } from '@mui/material';
 import PlaceholderImage from '@/assets/placeholder_cover_img.jpeg';
 import PlaceholderImageGray from '@/assets/placeholder_cover_img_gray.jpeg';
 
@@ -31,8 +31,11 @@ export const VendorCard = ({
   const theme = useTheme();
   const placeholderImage = (theme.palette.mode === 'light') ? PlaceholderImage : PlaceholderImageGray;
 
-  const handleFavorite = (vendorId: string) => {
+  const handleFavorite = (event: React.MouseEvent<HTMLButtonElement>, vendorId: string) => {
     // TO DO: implement the favorite logic here
+    event.stopPropagation();
+    event.preventDefault(); // Prevent link navigation
+
     console.log(`Favorite vendor ${vendorId}`);
   };
   return (
@@ -64,8 +67,28 @@ export const VendorCard = ({
             width: '100%',
             objectFit: 'cover', // Ensures the image covers the space without stretching
             objectPosition: 'center', // Adjust to prioritize faces (try 'center' if needed)
+            zIndex: 1
           }}
         />
+        {/* Favorite Button */}
+        {process.env.NODE_ENV === 'development' && (
+          // <Box sx={{ position: 'absolute', top: 8, right: 8 }}>
+          <IconButton
+            sx={{ position: 'absolute', display: 'block', top: 8, right: 8, fontSize: 24, cursor: 'pointer'}}
+            color='primary'
+            onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => handleFavorite(event, vendor.id)}
+          >
+            {isFavorite ? (
+              <FavoriteIcon
+                color='inherit'
+              />
+            ) : (
+              <FavoriteBorderIcon
+                color='inherit'
+              />
+            )}
+          </IconButton>
+        )}
         {/* Price Badges Container */}
         <Box
           sx={{
@@ -98,11 +121,8 @@ export const VendorCard = ({
               }}
             />
           )}
-
-
         </Box>
       </Box>
-
       <CardContent
         sx={{
           display: 'flex',
@@ -113,17 +133,6 @@ export const VendorCard = ({
           '&:last-child': { pb: 3 },
         }}
       >
-
-        {/* Favorite Button */}
-        {process.env.NODE_ENV === 'development' && (
-          <Box sx={{ position: 'absolute', top: 8, right: 8 }}>
-            {isFavorite ? (
-              <FavoriteIcon sx={{ fontSize: 24, cursor: 'pointer', color: 'pink' }} />
-            ) : (
-              <FavoriteBorderIcon sx={{ fontSize: 24, cursor: 'pointer' }} onClick={() => handleFavorite(vendor.id)} />
-            )}
-          </Box>
-        )}
         {/* Business Name */}
         <Typography
           variant="h4"
@@ -162,6 +171,6 @@ export const VendorCard = ({
         </Box>
 
       </CardContent>
-    </Card>
+    </Card >
   );
 };

--- a/frontend/src/features/directory/components/VendorCard.tsx
+++ b/frontend/src/features/directory/components/VendorCard.tsx
@@ -72,7 +72,6 @@ export const VendorCard = ({
         />
         {/* Favorite Button */}
         {process.env.NODE_ENV === 'development' && (
-          // <Box sx={{ position: 'absolute', top: 8, right: 8 }}>
           <IconButton
             sx={{ position: 'absolute', display: 'block', top: 8, right: 8, fontSize: 24, cursor: 'pointer'}}
             color='primary'

--- a/frontend/src/features/directory/components/VendorCard.tsx
+++ b/frontend/src/features/directory/components/VendorCard.tsx
@@ -7,6 +7,8 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import LocationOnIconOutlined from '@mui/icons-material/LocationOnOutlined';
 import PublicIcon from '@mui/icons-material/Public';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
 import { useTheme } from '@mui/material';
 import PlaceholderImage from '@/assets/placeholder_cover_img.jpeg';
 import PlaceholderImageGray from '@/assets/placeholder_cover_img_gray.jpeg';
@@ -17,16 +19,22 @@ export const VendorCard = ({
   onBlur,
   tabIndex,
   className,
+  isFavorite
 }: {
   vendor: Vendor;
   onFocus: () => void;
   onBlur: () => void;
   tabIndex: number;
   className: string;
+  isFavorite?: boolean;
 }) => {
   const theme = useTheme();
-  const placeholderImage = (theme.palette.mode === 'light')? PlaceholderImage : PlaceholderImageGray;
+  const placeholderImage = (theme.palette.mode === 'light') ? PlaceholderImage : PlaceholderImageGray;
 
+  const handleFavorite = (vendorId: string) => {
+    // TO DO: implement the favorite logic here
+    console.log(`Favorite vendor ${vendorId}`);
+  };
   return (
     <Card
       elevation={1}
@@ -105,6 +113,17 @@ export const VendorCard = ({
           '&:last-child': { pb: 3 },
         }}
       >
+
+        {/* Favorite Button */}
+        {process.env.NODE_ENV === 'development' && (
+          <Box sx={{ position: 'absolute', top: 8, right: 8 }}>
+            {isFavorite ? (
+              <FavoriteIcon sx={{ fontSize: 24, cursor: 'pointer', color: 'pink' }} />
+            ) : (
+              <FavoriteBorderIcon sx={{ fontSize: 24, cursor: 'pointer' }} onClick={() => handleFavorite(vendor.id)} />
+            )}
+          </Box>
+        )}
         {/* Business Name */}
         <Typography
           variant="h4"

--- a/frontend/src/features/directory/components/VendorGrid.tsx
+++ b/frontend/src/features/directory/components/VendorGrid.tsx
@@ -35,6 +35,7 @@ export function VendorGrid({
               onBlur={handleBlur}
               tabIndex={0}
               className={focusedCardIndex === 0 ? 'Mui-focused' : ''}
+              isFavorite={Math.random() < 0.5} //todo: replace with user value
             >
             </VendorCard>
           </Link>

--- a/frontend/src/features/favorites/FavoriteTable.tsx
+++ b/frontend/src/features/favorites/FavoriteTable.tsx
@@ -19,7 +19,6 @@ export default function FavoriteTable({ favoriteVendors }: {
   };
   return (
     <div>
-      <h1>My Favorites</h1>
       <VendorGrid
         vendors={favoriteVendors}
         searchParams=''

--- a/frontend/src/features/favorites/Favorites.tsx
+++ b/frontend/src/features/favorites/Favorites.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { Vendor } from '@/types/vendor';
+import { VendorGrid } from '@/features/directory/components/VendorGrid';
+import { useState } from 'react';
+
+export default function FavoriteTable({ favoriteVendors }: {
+  favoriteVendors: Vendor[]
+}) {
+
+  const [focusedCardIndex, setFocusedCardIndex] = useState<number | null>(null);
+
+
+  const handleFocus = (index: number) => {
+    setFocusedCardIndex(index);
+  };
+
+  const handleBlur = () => {
+    setFocusedCardIndex(null);
+  };
+  return (
+    <div>
+      <h1>My Favorites</h1>
+      <VendorGrid
+        vendors={favoriteVendors}
+        searchParams=''
+        handleBlur={handleBlur}
+        handleFocus={handleFocus}
+        focusedCardIndex={focusedCardIndex}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
New favorites page:
<img width="1460" alt="Screenshot 2025-03-20 at 4 11 19 PM" src="https://github.com/user-attachments/assets/b3538ef4-f48d-4c6c-b202-a6c78264ec2f" />

Directory page also has heart button for favoriting:
<img width="1256" alt="Screenshot 2025-03-20 at 4 10 34 PM" src="https://github.com/user-attachments/assets/074fb0a3-b11c-4fab-bf0e-39a51dc12864" />

Business page displays heart next to name if it's favorite. You can also add/remove to favorites with the button
<img width="1473" alt="Screenshot 2025-03-20 at 4 08 27 PM" src="https://github.com/user-attachments/assets/57122ffe-6e75-4afe-a190-e9f64d99215d" />
<img width="1440" alt="Screenshot 2025-03-20 at 4 08 07 PM" src="https://github.com/user-attachments/assets/bf1ee01f-8cee-4a00-8e6a-1d6e9679349f" />
