### PR TITLE
Fix login and signup bugs

### DIFF
--- a/frontend/src/app/auth/callback/confirm-signup/page.tsx
+++ b/frontend/src/app/auth/callback/confirm-signup/page.tsx
@@ -1,0 +1,96 @@
+// app/page.js
+'use client';
+
+import { useState, useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Button, Container, Typography, Box, Paper, CircularProgress } from '@mui/material';
+import { createClient } from '@/lib/supabase/client';
+
+function ConfirmSignUpContent() {
+  const searchParams = useSearchParams();
+  const confirmationUrl = searchParams.get('confirmation_url');
+  const [isAlreadyAuthenticated, setIsAlreadyAuthenticated] = useState(false);
+
+  useEffect(() => {
+    // Check if user is already authenticated
+    const checkAuthStatus = async () => {
+      const supabase = createClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (session) {
+        setIsAlreadyAuthenticated(true);
+      }
+    };
+
+    checkAuthStatus();
+  }, []);
+  return (
+    <Container maxWidth="md">
+      <Paper elevation={3} sx={{ p: 4, mt: 8, borderRadius: 2 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
+          <Typography variant="h4" component="h1" align="center" gutterBottom>
+            Confirm Sign Up
+          </Typography>
+
+          {isAlreadyAuthenticated ? (
+            <>
+              <Typography variant="body1" align="center" component={'p'}>
+                You are already verified and signed in to your account.
+              </Typography>
+
+              <Button
+                variant="contained"
+                color="primary"
+                href="/"
+                size="large"
+              >
+                Go to Directory
+              </Button>
+            </>
+          ) : (
+            <>
+              <Typography variant="body1" align="center" component={'p'}>
+                Please click the button below to verify your email address and set up your account.
+              </Typography>
+
+              {confirmationUrl ? (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  component="a"
+                  href={confirmationUrl}
+                  size="large"
+                >
+                  Confirm Now
+                </Button>
+              ) : (
+                <Typography color="error">
+                  No confirmation URL provided. Please check the link and try again.
+                </Typography>
+              )}
+            </>
+          )}
+        </Box>
+      </Paper>
+    </Container>
+  );
+}
+
+// A loading component to show while suspense is resolving
+function LoadingState() {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+      <CircularProgress />
+    </Box>
+  );
+}
+
+// Main page component with Suspense boundary
+export default function ConfirmSignUpPage() {
+  return (
+    <Container maxWidth="md">
+      <Suspense fallback={<LoadingState />}>
+        <ConfirmSignUpContent />
+      </Suspense>
+    </Container>
+  );
+}

--- a/frontend/src/app/auth/callback/confirm-signup/page.tsx
+++ b/frontend/src/app/auth/callback/confirm-signup/page.tsx
@@ -1,4 +1,3 @@
-// app/page.js
 'use client';
 
 import { useState, useEffect, Suspense } from 'react';

--- a/frontend/src/app/auth/callback/confirm-signup/page.tsx
+++ b/frontend/src/app/auth/callback/confirm-signup/page.tsx
@@ -47,23 +47,26 @@ function ConfirmSignUpContent() {
             </>
           ) : (
             <>
-              <Typography variant="body1" align="center" component={'p'}>
-                Please click the button below to verify your email address and set up your account.
-              </Typography>
 
               {confirmationUrl ? (
-                <Button
-                  variant="contained"
-                  color="primary"
-                  component="a"
-                  href={confirmationUrl}
-                  size="large"
-                >
-                  Confirm Now
-                </Button>
+                <>
+                  <Typography variant="body1" align="center" component={'p'}>
+                    Please click the button below to verify your email address and set up your account.
+                  </Typography>
+
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    component="a"
+                    href={confirmationUrl}
+                    size="large"
+                  >
+                    Confirm Now
+                  </Button>
+                </>
               ) : (
                 <Typography color="error">
-                  No confirmation URL provided. Please check the link and try again.
+                  There was an error verifying your email address. Please check the link and try again.
                 </Typography>
               )}
             </>

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -17,17 +17,26 @@ export default function AuthCallbackPage() {
       const supabase = createClient();
       const { data: { session }, error } = await supabase.auth.getSession();
 
-      // Get the hash and search params from the URL
-      const hash = window.location.hash;
+
+      // If we have a session, redirect to home
+      if (session) {
+        setMessage("Account is verified! Redirecting to homepage...");
+        setTimeout(() => {
+          router.push("/");
+        }, 2000);
+        return;
+      }
+
+      // Get the search params from the URL
       const searchParams = new URLSearchParams(window.location.search);
+      const type = searchParams.get('type');
       const errorCode = searchParams.get('error_code');
 
       if (errorCode === 'otp_expired') {
         setIsError(true);
-        setMessage("Verification link has expired");
-        addNotification("The verification link has expired. Please request a new one.", "error");
+        setMessage("The verification link has expired. Please request a new one.");
         setTimeout(() => {
-          router.push("/auth/resend-verification");
+          router.push("/auth/verify-email");
         }, 2000);
         return;
       }
@@ -35,25 +44,19 @@ export default function AuthCallbackPage() {
       if (error) {
         setIsError(true);
         setMessage("Authentication error: " + error.message);
-        addNotification("Authentication failed: " + error.message, "error");
-        return;
-      }
 
-      // If this was an email verification
-      if (hash && hash.includes("type=signup")) {
-        addNotification("Email verified successfully! You can now log in with your account.");
-        setMessage("Email verified successfully!");
-        
         // Redirect to login after 2 seconds
         setTimeout(() => {
-          router.push("/login");
+          router.push("/");
         }, 2000);
         return;
       }
 
-      // If we have a session, redirect to home
-      if (session) {
-        setMessage("Authentication successful!");
+      if (type === 'signup') {
+        // email is successfully verified
+        setMessage("Authentication successful! Redirecting to homepage...");
+
+        // Redirect to homepage after 2 seconds
         setTimeout(() => {
           router.push("/");
         }, 2000);
@@ -61,9 +64,10 @@ export default function AuthCallbackPage() {
       }
 
       // If no session and no specific error, show a generic message
-      setMessage("Processing authentication...");
+      setIsError(true);
+      setMessage("Authentication failed. Redirecting to homepage... ");
       setTimeout(() => {
-        router.push("/login");
+        router.push("/");
       }, 2000);
     };
 

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -20,7 +20,7 @@ export default function AuthCallbackPage() {
 
       // If we have a session, redirect to home
       if (session) {
-        setMessage("Account is verified! Redirecting to homepage...");
+        setMessage("Authentication successful! Redirecting to homepage...");
         setTimeout(() => {
           router.push("/");
         }, 2000);
@@ -54,7 +54,7 @@ export default function AuthCallbackPage() {
 
       if (type === 'signup') {
         // email is successfully verified
-        setMessage("Authentication successful! Redirecting to homepage...");
+        setMessage("Email is verified! Redirecting to homepage...");
 
         // Redirect to homepage after 2 seconds
         setTimeout(() => {

--- a/frontend/src/app/auth/verify-email/page.tsx
+++ b/frontend/src/app/auth/verify-email/page.tsx
@@ -1,4 +1,4 @@
-import { Container, Typography, Paper, Box, Button, Alert } from "@mui/material";
+import { Container, Typography, Paper, Box, Button } from "@mui/material";
 import Link from "next/link";
 import { ResendVerificationForm } from "@/features/login/components/ResendVerificationForm";
 
@@ -10,14 +10,11 @@ export default function VerifyEmailPage() {
           <Typography variant="h4" component="h1" align="center" gutterBottom>
             Verify Your Email
           </Typography>
+          <Typography variant="body1" component={"p"}>
+            Please check your inbox for a verification link from us.
+          </Typography>
           
-          <Alert severity="info" sx={{ mb: 3 }}>
-            <Typography variant="body1">
-              We&apos;ve sent a verification email to your inbox. Please check your email and click the verification link to complete your signup.
-            </Typography>
-          </Alert>
-          
-          <Typography variant="body1" paragraph>
+          <Typography variant="body1">
             If you don&apos;t see the email:
           </Typography>
           
@@ -34,7 +31,7 @@ export default function VerifyEmailPage() {
           </Box>
 
           <Typography variant="h6" gutterBottom>
-            Need a new verification link?
+            Need a new verification link? Enter your email below:
           </Typography>
           
           <ResendVerificationForm />

--- a/frontend/src/app/auth/verify-email/page.tsx
+++ b/frontend/src/app/auth/verify-email/page.tsx
@@ -11,7 +11,7 @@ export default function VerifyEmailPage() {
             Verify Your Email
           </Typography>
           <Typography variant="body1" component={"p"}>
-            Please check your inbox for a verification link from us.
+            Please check your email for a verification link.
           </Typography>
           
           <Typography variant="body1">

--- a/frontend/src/features/login/api/actions.ts
+++ b/frontend/src/features/login/api/actions.ts
@@ -67,6 +67,7 @@ export async function signup(formData: FormData) {
   });
 
   if (error) {
+    console.log(error)
     switch (error.code) {
       case 'email_exists':
         return { 

--- a/frontend/src/features/login/api/actions.ts
+++ b/frontend/src/features/login/api/actions.ts
@@ -67,7 +67,6 @@ export async function signup(formData: FormData) {
   });
 
   if (error) {
-    console.log(error)
     switch (error.code) {
       case 'email_exists':
         return { 

--- a/frontend/src/features/login/components/LoginForm.tsx
+++ b/frontend/src/features/login/components/LoginForm.tsx
@@ -64,7 +64,7 @@ export function LoginForm() {
                   component={NextLink}
                   href="/auth/verify-email"
                 >
-                  Resend verification email
+                  Get a new verification link
                 </Button>
               </Box>
             </Alert>

--- a/frontend/src/features/login/components/ResendVerificationForm.tsx
+++ b/frontend/src/features/login/components/ResendVerificationForm.tsx
@@ -33,7 +33,6 @@ export function ResendVerificationForm() {
       if (error) {
         addNotification(error.message || 'Failed to send verification email', 'error');
       } else {
-        addNotification('If your email is associated with an account, we will send a verification email to you! Please check your inbox');
         setIsSuccess(true);
       }
     } catch (error) {

--- a/frontend/src/features/login/components/SignupForm.tsx
+++ b/frontend/src/features/login/components/SignupForm.tsx
@@ -46,7 +46,6 @@ export function SignupForm() {
 
     try {
       const result = await signup(formData);
-      console.log(result);
       if (result && result.error) {
         addNotification(result.error, 'error');
         if (result.action === 'login') {

--- a/frontend/src/features/login/components/SignupForm.tsx
+++ b/frontend/src/features/login/components/SignupForm.tsx
@@ -46,7 +46,7 @@ export function SignupForm() {
 
     try {
       const result = await signup(formData);
-      
+      console.log(result);
       if (result && result.error) {
         addNotification(result.error, 'error');
         if (result.action === 'login') {


### PR DESCRIPTION
Email verification flow:
1. User creates account or requests another verification link
2. Send email link
3. Email link goes to confirm-signup page. If the user is not logged in, the page has a button to "confirm" 
4. Pressing confirm button performs the supabase verification and redirects to callback page
5. Based on supabase verification, callback page displays success/error message, then redirects user to appropriate page

The extra confirm-signup page is necessary for a couple reasons. Many email providers will visit the verification link, which will verify the account without any user action... not what we want. The link is also one-time-use, so the verification invalid when the user clicks on it later, which is confusing. Also, clicking an invalid/expired verification link will sign user out if they happen to be logged in, since supabase tried and failed to authenticate. The confirm-signup page prevents these problems.

Note: supabase is configured to use localhost for the confirmation domain. This needs to be updated to our website once we release the feature