### PR TITLE
support PKCE password reset

### DIFF
--- a/frontend/src/app/auth/auth-code-error/page.tsx
+++ b/frontend/src/app/auth/auth-code-error/page.tsx
@@ -73,7 +73,7 @@ export default function AuthCodeErrorPage() {
 
           <Box sx={{ mt: 4, textAlign: 'center' }}>
             <Typography variant="body2" color="text.secondary">
-              If you continue to experience issues, please contact support.
+              If you continue to experience issues, please contact <Link href="/contact">support</Link>.
             </Typography>
           </Box>
         </Paper>

--- a/frontend/src/app/auth/confirm/route.ts
+++ b/frontend/src/app/auth/confirm/route.ts
@@ -28,5 +28,8 @@ export async function GET(request: NextRequest) {
   }
 
   // redirect the user to an error page with some instructions
+  if (type === 'recovery') {
+    redirect('/auth/recovery-code-error')    
+  }
   redirect('/auth/auth-code-error')
 }

--- a/frontend/src/app/auth/recovery-code-error/page.tsx
+++ b/frontend/src/app/auth/recovery-code-error/page.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { Container, Typography, Box, Button, Paper, Stack, Divider, Link } from '@mui/material'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import HomeIcon from '@mui/icons-material/Home'
+import RefreshIcon from '@mui/icons-material/Refresh'
+
+export default function AuthCodeErrorPage() {
+
+  return (
+    <Container maxWidth="sm">
+      <Box sx={{ my: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <Paper elevation={3} sx={{ p: 4, width: '100%', borderRadius: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
+            <ErrorOutlineIcon color="error" sx={{ fontSize: 40, mr: 2 }} />
+            <Typography variant="h4" component="h1" fontWeight="bold">
+              Password Reset Link Failed
+            </Typography>
+          </Box>
+
+          <Typography variant="body1" component={"p"} gutterBottom>
+            We couldn&apos;t verify your account for password reset. This could be because:
+          </Typography>
+
+          <Box sx={{ ml: 2, mb: 3 }}>
+            <Typography variant="body1" component={"p"}>
+              • The reset link has expired
+            </Typography>
+            <Typography variant="body1" component={"p"}>
+              • The reset link was already used
+            </Typography>
+          </Box>
+
+          <Divider sx={{ mb: 3 }} />
+
+          <Typography variant="h6" gutterBottom>
+            What you can do:
+          </Typography>
+
+          <Stack spacing={2} alignItems="center" sx={{ mt: 3 }}>
+            <Link href="/reset-password" style={{ textDecoration: 'none' }}>
+              <Button
+                variant="contained"
+                color="primary"
+                startIcon={<RefreshIcon />}
+              >
+                Request another password reset link
+              </Button>
+            </Link>
+            <Link href="/" style={{ textDecoration: 'none' }}>
+              <Button
+                variant="outlined"
+                color="primary"
+                startIcon={<HomeIcon />}
+              >
+                Return to homepage
+              </Button>
+            </Link>
+          </Stack>
+
+          <Box sx={{ mt: 4, textAlign: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              If you continue to experience issues, please contact support.
+            </Typography>
+          </Box>
+        </Paper>
+      </Box>
+    </Container>
+  )
+}

--- a/frontend/src/app/auth/recovery-code-error/page.tsx
+++ b/frontend/src/app/auth/recovery-code-error/page.tsx
@@ -60,7 +60,7 @@ export default function AuthCodeErrorPage() {
 
           <Box sx={{ mt: 4, textAlign: 'center' }}>
             <Typography variant="body2" color="text.secondary">
-              If you continue to experience issues, please contact support.
+              If you continue to experience issues, please contact <Link href="/contact">support</Link>.
             </Typography>
           </Box>
         </Paper>

--- a/frontend/src/app/auth/reset-password/page.tsx
+++ b/frontend/src/app/auth/reset-password/page.tsx
@@ -3,14 +3,14 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
-    Box,
-    Container,
-    Typography,
-    TextField,
-    Button,
-    List,
-    ListItem,
-    Alert,
+  Box,
+  Container,
+  Typography,
+  TextField,
+  Button,
+  List,
+  ListItem,
+  Alert,
 } from '@mui/material';
 import { useNotification } from '@/contexts/NotificationContext';
 import { validatePassword } from '@/utils/passwordValidation';
@@ -18,127 +18,127 @@ import { createClient } from '@/lib/supabase/client';
 import { updatePasswordAfterReset } from '@/features/settings/api/updatePassword';
 
 interface ApiError extends Error {
-    message: string;
+  message: string;
 }
 
 export default function UpdatePasswordAfterResetPage() {
-    const { addNotification } = useNotification();
-    const [newPassword, setNewPassword] = useState('');
-    const [confirmPassword, setConfirmPassword] = useState('');
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [passwordError, setPasswordError] = useState<string | null>(null);
-    const router = useRouter();
-    const supabase = createClient();
+  const { addNotification } = useNotification();
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const router = useRouter();
+  const supabase = createClient();
 
-    useEffect(() => {
-        async function checkLogin() {
-            const { data: { session } } = await supabase.auth.getSession();
+  useEffect(() => {
+    async function checkLogin() {
+      const { data: { session } } = await supabase.auth.getSession();
 
-            if (!session) {
-                router.push('/login');
-                return;
-            }
+      if (!session) {
+        router.push('/login');
+        return;
+      }
+    }
+    checkLogin();
+  }, [router, supabase.auth]);
+
+  const handlePasswordChange = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setPasswordError(null);
+
+    if (newPassword !== confirmPassword) {
+      addNotification('New passwords do not match', 'error');
+      setIsSubmitting(false);
+      return;
+    }
+
+    const validation = validatePassword(newPassword);
+    if (!validation.isValid) {
+      setPasswordError(validation.message);
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      await updatePasswordAfterReset(newPassword);
+      addNotification('Password updated successfully. Redirecting to login page...');
+      await supabase.auth.signOut();
+      setTimeout(() => {
+        router.push('/login');
+      }, 2000);
+
+    } catch (error: unknown) {
+      const apiError = error as ApiError;
+      addNotification(apiError.message || 'Failed to update password', 'error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 4, mb: 4, display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Update Password
+      </Typography>
+
+      <List sx={{
+        width: '100%',
+        '& .MuiListItemButton-root': {
+          py: 2,
+          justifyContent: 'flex-start',
         }
-        checkLogin();
-    }, [router, supabase.auth]);
-
-    const handlePasswordChange = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setIsSubmitting(true);
-        setPasswordError(null);
-
-        if (newPassword !== confirmPassword) {
-            addNotification('New passwords do not match', 'error');
-            setIsSubmitting(false);
-            return;
-        }
-
-        const validation = validatePassword(newPassword);
-        if (!validation.isValid) {
-            setPasswordError(validation.message);
-            setIsSubmitting(false);
-            return;
-        }
-
-        try {
-            await updatePasswordAfterReset(newPassword);
-            addNotification('Password updated successfully. Redirecting to login page...');
-            await supabase.auth.signOut();
-            setTimeout(() => {
-                router.push('/login');
-            }, 2000);
-
-        } catch (error: unknown) {
-            const apiError = error as ApiError;
-            addNotification(apiError.message || 'Failed to update password', 'error');
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
-
-    return (
-        <Container maxWidth="sm" sx={{ mt: 4, mb: 4, display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
-            <Typography variant="h4" component="h1" gutterBottom>
-                Update Password
-            </Typography>
-
-            <List sx={{
-                width: '100%',
-                '& .MuiListItemButton-root': {
-                    py: 2,
-                    justifyContent: 'flex-start',
-                }
-            }}>
-                <ListItem disablePadding>
-                    <form onSubmit={handlePasswordChange}>
-                        <TextField
-                            fullWidth
-                            type="password"
-                            label="New Password"
-                            value={newPassword}
-                            onChange={(e) => {
-                                setNewPassword(e.target.value);
-                                setPasswordError(null);
-                            }}
-                            margin="normal"
-                            required
-                            disabled={isSubmitting}
-                            error={!!passwordError}
-                            helperText={passwordError}
-                        />
-                        <TextField
-                            fullWidth
-                            type="password"
-                            label="Confirm New Password"
-                            value={confirmPassword}
-                            onChange={(e) => setConfirmPassword(e.target.value)}
-                            margin="normal"
-                            required
-                            disabled={isSubmitting}
-                        />
-                        <Alert severity="info" sx={{ mt: 2 }}>
-                            Password must contain:
-                            <Box component="ul" sx={{ mt: 1, mb: 0, pl: 2 }}>
-                                <Box component="li">At least 8 characters</Box>
-                                <Box component="li">At least one uppercase letter</Box>
-                                <Box component="li">At least one lowercase letter</Box>
-                                <Box component="li">At least one number</Box>
-                                <Box component="li">At least one special character: {'!@#$%^&*(),.?'}</Box>
-                            </Box>
-                        </Alert>
-                        <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
-                            <Button
-                                type="submit"
-                                variant="contained"
-                                color="primary"
-                                disabled={isSubmitting}
-                            >
-                                {isSubmitting ? 'Updating...' : 'Update Password'}
-                            </Button>
-                        </Box>
-                    </form>
-                </ListItem>
-            </List>
-        </Container>
-    );
+      }}>
+        <ListItem disablePadding>
+          <form onSubmit={handlePasswordChange}>
+            <TextField
+              fullWidth
+              type="password"
+              label="New Password"
+              value={newPassword}
+              onChange={(e) => {
+                setNewPassword(e.target.value);
+                setPasswordError(null);
+              }}
+              margin="normal"
+              required
+              disabled={isSubmitting}
+              error={!!passwordError}
+              helperText={passwordError}
+            />
+            <TextField
+              fullWidth
+              type="password"
+              label="Confirm New Password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              margin="normal"
+              required
+              disabled={isSubmitting}
+            />
+            <Alert severity="info" sx={{ mt: 2 }}>
+              Password must contain:
+              <Box component="ul" sx={{ mt: 1, mb: 0, pl: 2 }}>
+                <Box component="li">At least 8 characters</Box>
+                <Box component="li">At least one uppercase letter</Box>
+                <Box component="li">At least one lowercase letter</Box>
+                <Box component="li">At least one number</Box>
+                <Box component="li">At least one special character: {'!@#$%^&*(),.?'}</Box>
+              </Box>
+            </Alert>
+            <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+              <Button
+                type="submit"
+                variant="contained"
+                color="primary"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Updating...' : 'Update Password'}
+              </Button>
+            </Box>
+          </form>
+        </ListItem>
+      </List>
+    </Container>
+  );
 } 

--- a/frontend/src/app/auth/reset-password/page.tsx
+++ b/frontend/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+    Box,
+    Container,
+    Typography,
+    TextField,
+    Button,
+    List,
+    ListItem,
+    Alert,
+} from '@mui/material';
+import { useNotification } from '@/contexts/NotificationContext';
+import { validatePassword } from '@/utils/passwordValidation';
+import { createClient } from '@/lib/supabase/client';
+import { updatePasswordAfterReset } from '@/features/settings/api/updatePassword';
+
+interface ApiError extends Error {
+    message: string;
+}
+
+export default function UpdatePasswordAfterResetPage() {
+    const { addNotification } = useNotification();
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [passwordError, setPasswordError] = useState<string | null>(null);
+    const router = useRouter();
+    const supabase = createClient();
+
+    useEffect(() => {
+        async function checkLogin() {
+            const { data: { session } } = await supabase.auth.getSession();
+
+            if (!session) {
+                router.push('/login');
+                return;
+            }
+        }
+        checkLogin();
+    }, [router, supabase.auth]);
+
+    const handlePasswordChange = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setIsSubmitting(true);
+        setPasswordError(null);
+
+        if (newPassword !== confirmPassword) {
+            addNotification('New passwords do not match', 'error');
+            setIsSubmitting(false);
+            return;
+        }
+
+        const validation = validatePassword(newPassword);
+        if (!validation.isValid) {
+            setPasswordError(validation.message);
+            setIsSubmitting(false);
+            return;
+        }
+
+        try {
+            await updatePasswordAfterReset(newPassword);
+            addNotification('Password updated successfully. Redirecting to login page...');
+            await supabase.auth.signOut();
+            setTimeout(() => {
+                router.push('/login');
+            }, 2000);
+
+        } catch (error: unknown) {
+            const apiError = error as ApiError;
+            addNotification(apiError.message || 'Failed to update password', 'error');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Container maxWidth="sm" sx={{ mt: 4, mb: 4, display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+            <Typography variant="h4" component="h1" gutterBottom>
+                Update Password
+            </Typography>
+
+            <List sx={{
+                width: '100%',
+                '& .MuiListItemButton-root': {
+                    py: 2,
+                    justifyContent: 'flex-start',
+                }
+            }}>
+                <ListItem disablePadding>
+                    <form onSubmit={handlePasswordChange}>
+                        <TextField
+                            fullWidth
+                            type="password"
+                            label="New Password"
+                            value={newPassword}
+                            onChange={(e) => {
+                                setNewPassword(e.target.value);
+                                setPasswordError(null);
+                            }}
+                            margin="normal"
+                            required
+                            disabled={isSubmitting}
+                            error={!!passwordError}
+                            helperText={passwordError}
+                        />
+                        <TextField
+                            fullWidth
+                            type="password"
+                            label="Confirm New Password"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            margin="normal"
+                            required
+                            disabled={isSubmitting}
+                        />
+                        <Alert severity="info" sx={{ mt: 2 }}>
+                            Password must contain:
+                            <Box component="ul" sx={{ mt: 1, mb: 0, pl: 2 }}>
+                                <Box component="li">At least 8 characters</Box>
+                                <Box component="li">At least one uppercase letter</Box>
+                                <Box component="li">At least one lowercase letter</Box>
+                                <Box component="li">At least one number</Box>
+                                <Box component="li">At least one special character: {'!@#$%^&*(),.?'}</Box>
+                            </Box>
+                        </Alert>
+                        <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+                            <Button
+                                type="submit"
+                                variant="contained"
+                                color="primary"
+                                disabled={isSubmitting}
+                            >
+                                {isSubmitting ? 'Updating...' : 'Update Password'}
+                            </Button>
+                        </Box>
+                    </form>
+                </ListItem>
+            </List>
+        </Container>
+    );
+} 

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -1,14 +1,14 @@
 import { Container, Typography } from "@mui/material";
-import { ResetPasswordForm } from "@/features/login/components/ResetPasswordForm";
+import { ForgotPasswordForm } from "@/features/login/components/ResetPasswordForm";
 
-export default function ResetPasswordPage() {
+export default function ForgotPasswordPage() {
   return (
     <Container maxWidth="sm">
       <br />
       <Typography variant="h1" gutterBottom sx={{ mt: 2 }}>
         Reset Password
       </Typography>
-      <ResetPasswordForm />
+      <ForgotPasswordForm />
     </Container>
   );
 } 

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,14 @@
+import { Container, Typography } from "@mui/material";
+import { ResetPasswordForm } from "@/features/login/components/ResetPasswordForm";
+
+export default function ResetPasswordPage() {
+    return (
+        <Container maxWidth="sm">
+            <br />
+            <Typography variant="h1" gutterBottom sx={{ mt: 2 }}>
+                Reset Password
+            </Typography>
+            <ResetPasswordForm />
+        </Container>
+    );
+} 

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -2,13 +2,13 @@ import { Container, Typography } from "@mui/material";
 import { ResetPasswordForm } from "@/features/login/components/ResetPasswordForm";
 
 export default function ResetPasswordPage() {
-    return (
-        <Container maxWidth="sm">
-            <br />
-            <Typography variant="h1" gutterBottom sx={{ mt: 2 }}>
-                Reset Password
-            </Typography>
-            <ResetPasswordForm />
-        </Container>
-    );
+  return (
+    <Container maxWidth="sm">
+      <br />
+      <Typography variant="h1" gutterBottom sx={{ mt: 2 }}>
+        Reset Password
+      </Typography>
+      <ResetPasswordForm />
+    </Container>
+  );
 } 

--- a/frontend/src/features/login/components/LoginForm.tsx
+++ b/frontend/src/features/login/components/LoginForm.tsx
@@ -116,7 +116,7 @@ export function LoginForm() {
               </Typography>
               <Typography variant="body2" align="center" sx={{ mt: 2 }}>
                 Forgot your password?{' '}
-                <Link component={NextLink} href="/reset-password">
+                <Link component={NextLink} href="/forgot-password">
                   Reset your password
                 </Link>
               </Typography>

--- a/frontend/src/features/login/components/LoginForm.tsx
+++ b/frontend/src/features/login/components/LoginForm.tsx
@@ -114,6 +114,12 @@ export function LoginForm() {
                   Sign up
                 </Link>
               </Typography>
+              <Typography variant="body2" align="center" sx={{ mt: 2 }}>
+                Forgot your password?{' '}
+                <Link component={NextLink} href="/reset-password">
+                  Reset your password
+                </Link>
+              </Typography>
             </Stack>
           </Box>
         </Paper>

--- a/frontend/src/features/login/components/ResetPasswordForm.tsx
+++ b/frontend/src/features/login/components/ResetPasswordForm.tsx
@@ -6,84 +6,84 @@ import { createClient } from '@/lib/supabase/client';
 import { useNotification } from '@/contexts/NotificationContext';
 
 export function ResetPasswordForm() {
-    const { addNotification } = useNotification();
-    const [email, setEmail] = useState('');
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [isSuccess, setIsSuccess] = useState(false);
+  const { addNotification } = useNotification();
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        if (!email) {
-            addNotification('Please enter your email address', 'error');
-            return;
-        }
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email) {
+      addNotification('Please enter your email address', 'error');
+      return;
+    }
 
-        setIsSubmitting(true);
+    setIsSubmitting(true);
 
-        try {
-            const supabase = createClient();
-            const { error } = await supabase.auth.resetPasswordForEmail(email, {
-                redirectTo: `${window.location.origin}/auth/update-password`,
-            })
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${window.location.origin}/auth/update-password`,
+      })
 
-            if (error) {
-                addNotification(error.message || 'Failed to send reset password email', 'error');
-            } else {
-                setIsSuccess(true);
-            }
-        } catch (error) {
-            console.error("An unexpected error occurred: " + error);
-            addNotification('An unexpected error occurred', 'error');
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
+      if (error) {
+        addNotification(error.message || 'Failed to send reset password email', 'error');
+      } else {
+        setIsSuccess(true);
+      }
+    } catch (error) {
+      console.error("An unexpected error occurred: " + error);
+      addNotification('An unexpected error occurred', 'error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
-    return (
-        <Container maxWidth="sm">
-            <Box sx={{ mt: 8, mb: 4 }}>
-                <Paper elevation={3} sx={{ p: 4 }}>
-                    <Typography variant="h4" component="h1" align="center" gutterBottom>
-                        Reset Password
-                    </Typography>
-                    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 2 }}>
-                        {isSuccess ? (
-                            <Alert severity="success" sx={{ mb: 2 }}>
-                                Reset password email has been sent! Please check your inbox and spam folder.
-                            </Alert>
-                        ) : (
-                            <>
-                                <TextField
-                                    margin="normal"
-                                    required
-                                    fullWidth
-                                    id="email"
-                                    label="Email Address"
-                                    name="email"
-                                    autoComplete="email"
-                                    autoFocus
-                                    variant="outlined"
-                                    value={email}
-                                    onChange={(e) => setEmail(e.target.value)}
-                                    disabled={isSubmitting}
-                                />
+  return (
+    <Container maxWidth="sm">
+      <Box sx={{ mt: 8, mb: 4 }}>
+        <Paper elevation={3} sx={{ p: 4 }}>
+          <Typography variant="h4" component="h1" align="center" gutterBottom>
+            Reset Password
+          </Typography>
+          <Box component="form" onSubmit={handleSubmit} sx={{ mt: 2 }}>
+            {isSuccess ? (
+              <Alert severity="success" sx={{ mb: 2 }}>
+                Reset password email has been sent! Please check your inbox and spam folder.
+              </Alert>
+            ) : (
+              <>
+                <TextField
+                  margin="normal"
+                  required
+                  fullWidth
+                  id="email"
+                  label="Email Address"
+                  name="email"
+                  autoComplete="email"
+                  autoFocus
+                  variant="outlined"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={isSubmitting}
+                />
 
-                                <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
-                                    <Button
-                                        type="submit"
-                                        variant="contained"
-                                        size="large"
-                                        disabled={isSubmitting}
-                                        startIcon={isSubmitting ? <CircularProgress size={20} /> : null}
-                                    >
-                                        {isSubmitting ? 'Sending...' : 'Send New Reset Password Email'}
-                                    </Button>
-                                </Box>
-                            </>
-                        )}
-                    </Box>
-                </Paper>
-            </Box>
-        </Container>
-    );
+                <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    size="large"
+                    disabled={isSubmitting}
+                    startIcon={isSubmitting ? <CircularProgress size={20} /> : null}
+                  >
+                    {isSubmitting ? 'Sending...' : 'Send New Reset Password Email'}
+                  </Button>
+                </Box>
+              </>
+            )}
+          </Box>
+        </Paper>
+      </Box>
+    </Container>
+  );
 } 

--- a/frontend/src/features/login/components/ResetPasswordForm.tsx
+++ b/frontend/src/features/login/components/ResetPasswordForm.tsx
@@ -5,7 +5,7 @@ import { Box, Button, TextField, CircularProgress, Alert, Container, Paper, Typo
 import { createClient } from '@/lib/supabase/client';
 import { useNotification } from '@/contexts/NotificationContext';
 
-export function ResetPasswordForm() {
+export function ForgotPasswordForm() {
   const { addNotification } = useNotification();
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/frontend/src/features/login/components/ResetPasswordForm.tsx
+++ b/frontend/src/features/login/components/ResetPasswordForm.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from 'react';
+import { Box, Button, TextField, CircularProgress, Alert, Container, Paper, Typography } from '@mui/material';
+import { createClient } from '@/lib/supabase/client';
+import { useNotification } from '@/contexts/NotificationContext';
+
+export function ResetPasswordForm() {
+    const { addNotification } = useNotification();
+    const [email, setEmail] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isSuccess, setIsSuccess] = useState(false);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!email) {
+            addNotification('Please enter your email address', 'error');
+            return;
+        }
+
+        setIsSubmitting(true);
+
+        try {
+            const supabase = createClient();
+            const { error } = await supabase.auth.resetPasswordForEmail(email, {
+                redirectTo: `${window.location.origin}/auth/update-password`,
+            })
+
+            if (error) {
+                addNotification(error.message || 'Failed to send reset password email', 'error');
+            } else {
+                setIsSuccess(true);
+            }
+        } catch (error) {
+            console.error("An unexpected error occurred: " + error);
+            addNotification('An unexpected error occurred', 'error');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Container maxWidth="sm">
+            <Box sx={{ mt: 8, mb: 4 }}>
+                <Paper elevation={3} sx={{ p: 4 }}>
+                    <Typography variant="h4" component="h1" align="center" gutterBottom>
+                        Reset Password
+                    </Typography>
+                    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 2 }}>
+                        {isSuccess ? (
+                            <Alert severity="success" sx={{ mb: 2 }}>
+                                Reset password email has been sent! Please check your inbox and spam folder.
+                            </Alert>
+                        ) : (
+                            <>
+                                <TextField
+                                    margin="normal"
+                                    required
+                                    fullWidth
+                                    id="email"
+                                    label="Email Address"
+                                    name="email"
+                                    autoComplete="email"
+                                    autoFocus
+                                    variant="outlined"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    disabled={isSubmitting}
+                                />
+
+                                <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
+                                    <Button
+                                        type="submit"
+                                        variant="contained"
+                                        size="large"
+                                        disabled={isSubmitting}
+                                        startIcon={isSubmitting ? <CircularProgress size={20} /> : null}
+                                    >
+                                        {isSubmitting ? 'Sending...' : 'Send New Reset Password Email'}
+                                    </Button>
+                                </Box>
+                            </>
+                        )}
+                    </Box>
+                </Paper>
+            </Box>
+        </Container>
+    );
+} 

--- a/frontend/src/features/login/components/ResetPasswordForm.tsx
+++ b/frontend/src/features/login/components/ResetPasswordForm.tsx
@@ -22,9 +22,7 @@ export function ResetPasswordForm() {
 
     try {
       const supabase = createClient();
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth/update-password`,
-      })
+      const { error } = await supabase.auth.resetPasswordForEmail(email);
 
       if (error) {
         addNotification(error.message || 'Failed to send reset password email', 'error');
@@ -76,7 +74,7 @@ export function ResetPasswordForm() {
                     disabled={isSubmitting}
                     startIcon={isSubmitting ? <CircularProgress size={20} /> : null}
                   >
-                    {isSubmitting ? 'Sending...' : 'Send New Reset Password Email'}
+                    {isSubmitting ? 'Sending...' : 'Send Link to Email'}
                   </Button>
                 </Box>
               </>

--- a/frontend/src/features/settings/api/updatePassword.ts
+++ b/frontend/src/features/settings/api/updatePassword.ts
@@ -18,3 +18,10 @@ export const updatePassword = async (currentPassword: string, newPassword: strin
   if (error) throw error;
 };
 
+export const updatePasswordAfterReset = async (newPassword: string) => {
+  const { error } = await supabase.auth.updateUser({
+    password: newPassword
+  });
+  if (error) throw error;
+};
+


### PR DESCRIPTION
PR is built on top of #39, following this guide for PKCE password reset: https://supabase.com/docs/guides/auth/passwords?queryGroups=flow&flow=pkce#resetting-a-password

Changes:
* instead of redirecting to "${window.location.origin}/auth/update-password" using the auth api, use the email template to pass the token params and next url to redirect to
* when clicking the link, go through the "confirm" route for OTP verification. If successful, redirect to password reset form. Otherwise, go to password error page

Testing:
The email template is using our domain, not the preview deployment urls. To test, follow the normal flow EXCEPT for clicking the email link. Instead of clicking, copy the link address and replace the "asianweddingmakeup" domain with the deployment url. Links are one-time use, so if you accidentally click the link, it won't work again.