### PR TITLE
Styling & naming of pricing and travels

### DIFF
--- a/frontend/src/features/directory/components/VendorCard.tsx
+++ b/frontend/src/features/directory/components/VendorCard.tsx
@@ -6,7 +6,8 @@ import CardMedia from '@mui/material/CardMedia';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import PaidOutlinedIcon from '@mui/icons-material/PaidOutlined';
+import LocationOn from '@mui/icons-material/LocationOn';
+import PaidIconOutlined from '@mui/icons-material/PaidOutlined';
 import PublicIcon from '@mui/icons-material/Public';
 import { useTheme } from '@mui/material';
 import PlaceholderImage from '@/assets/placeholder_cover_img.jpeg';
@@ -151,37 +152,39 @@ export const VendorCard = ({
             >
               {vendor.business_name}
             </Typography>
-
-            {/* Location */}
-            <Typography
-              variant="subtitle2"
-            >
-              {formatVendorLocation(vendor)}
-            </Typography>
+            <Stack direction="row" alignItems="center" spacing={0.5}>
+              {/* Location */}
+              <LocationOn fontSize='small' color='primary' />
+              <Typography
+                variant="subtitle2"
+              >
+                {formatVendorLocation(vendor)}
+              </Typography>
+            </Stack>
 
             <Stack direction="row" alignItems="center" gap={1.5} flexWrap="wrap">
               {/* Pricing */}
               {hasPricing && <Stack direction="row" alignItems="center" spacing={0.5}>
-                <PaidOutlinedIcon fontSize='small' />
+                <PaidIconOutlined fontSize='small' color='primary' />
                 <Typography
                   variant="body2"
                   fontWeight={'bold'}
                   noWrap
                 >
-                  From ${lowestServicePrice}+
+                  Starts at ${lowestServicePrice}
                 </Typography>
               </Stack>
               }
 
               {/* Worldwide travel */}
               {vendor.travels_world_wide && <Stack direction="row" alignItems="center" spacing={0.5}>
-                <PublicIcon fontSize='small' />
+                <PublicIcon fontSize='small' color='primary' />
                 <Typography
                   variant="body2"
                   fontWeight={'bold'}
                   noWrap
                 >
-                  Will Travel
+                  Travels
                 </Typography>
               </Stack>
               }


### PR DESCRIPTION
<img width="694" height="462" alt="Screenshot 2025-07-21 at 11 43 18 PM" src="https://github.com/user-attachments/assets/e18dd5c8-3897-43c7-b8b7-1fb5a01f4948" />
<img width="827" height="480" alt="Screenshot 2025-07-21 at 11 42 38 PM" src="https://github.com/user-attachments/assets/08ea36e6-e66c-4f9e-8147-9bc416096a7c" />
<img width="810" height="481" alt="Screenshot 2025-07-21 at 11 42 24 PM" src="https://github.com/user-attachments/assets/9c31060e-f992-4795-af6c-7d740523b20f" />
