### PR TITLE
Use cache for vendors in dev. Add on-demand cache invalidation

### DIFF
--- a/frontend/src/actions/cache.ts
+++ b/frontend/src/actions/cache.ts
@@ -1,0 +1,12 @@
+"use server";
+import { isDevelopment } from "@/lib/env/env";
+import { revalidateTag } from "next/cache";
+
+  export async function invalidateVendorCache() {
+  if (!isDevelopment()) {
+    console.warn('Cache invalidation only available in dev');
+    return;
+  }
+  
+  revalidateTag('vendors');
+}

--- a/frontend/src/components/layouts/DevTools.tsx
+++ b/frontend/src/components/layouts/DevTools.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import CheckIcon from '@mui/icons-material/Check';
+import ErrorIcon from '@mui/icons-material/Error';
+import { isDevelopment } from '@/lib/env/env';
+import { invalidateVendorCache } from '@/actions/cache';
+
+export default function DevTools() {
+  const [cacheStatus, setCacheStatus] = useState('ready');
+
+  // Don't render in production
+  if (!isDevelopment()) {
+    return null;
+  }
+
+  const handleCacheRefresh = async () => {
+    setCacheStatus('refreshing');
+    try {
+      await invalidateVendorCache();
+      setCacheStatus('refreshed');
+      setTimeout(() => setCacheStatus('ready'), 2000);
+    } catch (error) {
+      console.error('Cache refresh failed:', error);
+      setCacheStatus('error');
+      setTimeout(() => setCacheStatus('ready'), 2000);
+    }
+  };
+
+  const getButtonProps = () => {
+    switch (cacheStatus) {
+      case 'refreshing':
+        return {
+          children: 'Refreshing...',
+          startIcon: <CircularProgress size={16} />,
+          disabled: true
+        };
+      case 'refreshed':
+        return {
+          children: 'Refreshed!',
+          startIcon: <CheckIcon />,
+          disabled: false
+        };
+      case 'error':
+        return {
+          children: 'Error',
+          startIcon: <ErrorIcon />,
+          disabled: false
+        };
+      default:
+        return {
+          children: 'Refresh Vendors',
+          startIcon: <RefreshIcon />,
+          disabled: false
+        };
+    }
+  };
+
+  return (
+    <FormControl>
+      <FormLabel>Dev Tools</FormLabel>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mt: 1 }}>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={handleCacheRefresh}
+          color='info'
+          {...getButtonProps()}
+        />
+        
+        <Typography variant="caption" color="text.secondary">
+          Cache revalidates every 24h in prod
+        </Typography>
+        
+        {/* Easy to add more dev tools here */}
+        {/* 
+        <Divider sx={{ my: 1 }} />
+        <Button variant="outlined" size="small">
+          Clear All Storage
+        </Button>
+        <Button variant="outlined" size="small">
+          Mock Data Mode
+        </Button>
+        */}
+      </Box>
+    </FormControl>
+  );
+}

--- a/frontend/src/components/layouts/DevTools.tsx
+++ b/frontend/src/components/layouts/DevTools.tsx
@@ -76,17 +76,6 @@ export default function DevTools() {
         <Typography variant="caption" color="text.secondary">
           Cache revalidates every 24h in prod
         </Typography>
-        
-        {/* Easy to add more dev tools here */}
-        {/* 
-        <Divider sx={{ my: 1 }} />
-        <Button variant="outlined" size="small">
-          Clear All Storage
-        </Button>
-        <Button variant="outlined" size="small">
-          Mock Data Mode
-        </Button>
-        */}
       </Box>
     </FormControl>
   );

--- a/frontend/src/components/layouts/Navbar.tsx
+++ b/frontend/src/components/layouts/Navbar.tsx
@@ -36,7 +36,8 @@ import Favorite from "@mui/icons-material/Favorite";
 import Logout from "@mui/icons-material/Logout";
 import { createClient } from '@/lib/supabase/client';
 import { useNotification } from '@/contexts/NotificationContext';
-import { isDevOrPreview } from '@/lib/env/env';
+import { isDevelopment, isDevOrPreview } from '@/lib/env/env';
+import DevTools from './DevTools';
 
 const pages = ["About", "Contact", "FAQ", "Recommend"];
 const resources = ["Blog"];
@@ -446,6 +447,9 @@ export default function Navbar() {
             </Menu>
           </Box>
 
+          {isDevelopment() && (
+            <DevTools/>
+          )}
           {isDevOrPreview() && (
             <FormControl>
               <FormLabel id="demo-theme-toggle">Theme</FormLabel>

--- a/frontend/src/features/directory/api/fetchVendors.ts
+++ b/frontend/src/features/directory/api/fetchVendors.ts
@@ -1,5 +1,4 @@
 import { supabase } from '@/lib/api-client';
-import { isDevelopment } from '@/lib/env/env';
 import { transformBackendVendorToFrontend } from '@/types/vendor';
 import { unstable_cache } from 'next/cache';
 
@@ -24,6 +23,4 @@ export async function fetchAllVendors() {
   }
 }
 
-export const getCachedVendors = isDevelopment()
-  ? fetchAllVendors
-  : unstable_cache(fetchAllVendors, ["all-vendors"], { revalidate: 86400 });
+export const getCachedVendors = unstable_cache(fetchAllVendors, ["all-vendors"], { revalidate: 86400 });


### PR DESCRIPTION
We previously stopped using the cache for in dev and preview, in order to allow us to test new features. However these fetches still contribute to our egress data from supabase. 

This PR reinstates cache usage for dev and preview vendor fetches. It also adds a cache invalidation button on the NavBar for dev mode only. 