### PR TITLE
fix filter by state and region for premium. Improve back button

### DIFF
--- a/frontend/src/components/ui/BackButton.tsx
+++ b/frontend/src/components/ui/BackButton.tsx
@@ -4,10 +4,24 @@ import Button from "@mui/material/Button";
 
 export default function BackButton() {
   const router = useRouter();
+  const referrer = typeof document !== 'undefined' ? document.referrer : null; // Get the referrer (previous page)
+  const backUrl = referrer ? referrer : '/';
+
+  const handleBack = () => {
+    // If there's a referrer, use the browser's back action
+    if (referrer) {
+      router.back();
+    } else {
+      // If no referrer, navigate to the directory directly
+      router.push(backUrl);
+    }
+  };
+
+  const backButtonText = referrer ? '← Back' : '← Back to Directory';
 
   return (
-    <Button variant="text" onClick={() => router.back()} color="secondary">
-      ← Back
+    <Button variant="text" onClick={handleBack} color='secondary'>
+      {backButtonText}
     </Button>
   );
 }

--- a/frontend/src/features/directory/api/searchVendors.ts
+++ b/frontend/src/features/directory/api/searchVendors.ts
@@ -60,7 +60,7 @@ export async function getVendorsByState(location: LocationResult) {
 
 export function filterVendorsByCountry(location: LocationResult, vendors: VendorByDistance[]): VendorByDistance[] {
   if (!location.address?.country) {
-    console.warn("No state provided in location:", location);
+    console.warn("No country provided in location:", location);
     return [];
   } 
   return vendors.filter(vendor =>

--- a/frontend/src/features/directory/api/searchVendors.ts
+++ b/frontend/src/features/directory/api/searchVendors.ts
@@ -18,15 +18,25 @@ export async function getVendorsByLocation(location: LocationResult, vendors: Ve
   if (location.type === LOCATION_TYPE_PRESET_REGION) {
     return await filterVendorByRegion(location.display_name, vendors);
   } else if (isCountrySelection(location) && location.address?.country) {
-    return await getVendorsByCountry(location);
+    return filterVendorsByCountry(location, vendors);
   } else if (isStateSelection(location) && location.address?.state) {
-    return await getVendorsByState(location);
+    return filterVendorsByState(location, vendors);
   } else if (!!location.lat && !!location.lon) {
     return await getVendorsByDistanceWithFallback(location.lat, location.lon, SEARCH_RADIUS_MILES_DEFAULT, SEARCH_VENDORS_LIMIT_DEFAULT);
   } else {
     console.warn("Location type not recognized or missing coordinates:", location);
     return [];
   }
+}
+
+export function filterVendorsByState(location: LocationResult, vendors: VendorByDistance[]): VendorByDistance[] {
+  if (!location.address?.state) {
+    console.warn("No state provided in location:", location);
+    return [];
+  } 
+  return vendors.filter(vendor =>
+    vendor.state?.toLowerCase() === location.address?.state?.toLowerCase()
+  );
 }
 
 export async function getVendorsByState(location: LocationResult) {
@@ -45,6 +55,17 @@ export async function getVendorsByState(location: LocationResult) {
     return [];
   }
   return data;
+}
+
+
+export function filterVendorsByCountry(location: LocationResult, vendors: VendorByDistance[]): VendorByDistance[] {
+  if (!location.address?.country) {
+    console.warn("No state provided in location:", location);
+    return [];
+  } 
+  return vendors.filter(vendor =>
+    vendor.country?.toLowerCase() === location.address?.country?.toLowerCase()
+  );
 }
 
 export async function getVendorsByCountry(location: LocationResult) {


### PR DESCRIPTION
Previously filtering by state and country was a database call. This change filters from the base vendors instead, which saves db calls and also preserves the premium vendor data.

This also reverts to a previous version of the BackButton which handled more cases