### PR TITLE
Improve confusing behavior when adding vendor with no email

### DIFF
--- a/frontend/src/features/admin/api/createVendor.ts
+++ b/frontend/src/features/admin/api/createVendor.ts
@@ -75,14 +75,12 @@ export const createVendor = async (
 
       if (!hubspotContactId) {
         console.error("Failed to create HubSpot contact for vendor:", data.slug);
-        throw new Error("Failed to create HubSpot contact for vendor");
       }
       console.log("HubSpot contact created successfully!", hubspotContactId);
+    } else {
+      console.log("No email provided, skipping HubSpot contact creation for vendor:", data?.slug);
     }
-  } else {
-    console.log("No email provided, skipping HubSpot contact creation.");
   }
-
   if (error) {
     console.error("Error creating vendor:", error);
     throw error;

--- a/frontend/src/features/admin/api/createVendor.ts
+++ b/frontend/src/features/admin/api/createVendor.ts
@@ -63,20 +63,24 @@ export const createVendor = async (
       }
     })
 
-    // Create a contact in HubSpot
-    const hubspotContactId = await createHubSpotContact({
-      email: vendor.email || vendor.ig_handle || '',
-      firstname: firstname,
-      lastname: lastname,
-      slug: data.slug,
-      company: vendor.business_name ?? '',
-    });
+    // Create a contact in HubSpot if email is provided
+    if (vendor.email) {
+      const hubspotContactId = await createHubSpotContact({
+        email: vendor.email,
+        firstname: firstname,
+        lastname: lastname,
+        slug: data.slug,
+        company: vendor.business_name ?? '',
+      });
 
-    if (!hubspotContactId) {
-      console.error("Failed to create HubSpot contact for vendor:", data.slug);
-      throw new Error("Failed to create HubSpot contact for vendor");
+      if (!hubspotContactId) {
+        console.error("Failed to create HubSpot contact for vendor:", data.slug);
+        throw new Error("Failed to create HubSpot contact for vendor");
+      }
+      console.log("HubSpot contact created successfully!", hubspotContactId);
     }
-    console.log("HubSpot contact created successfully!", hubspotContactId);
+  } else {
+    console.log("No email provided, skipping HubSpot contact creation.");
   }
 
   if (error) {


### PR DESCRIPTION
Current behavior: if a vendor email is missing upon creation, Hubspot contact creation fails and the app shows an error message for the overall vendor creation. This is confusing because, the supabase vendor creation was successful, and only the non-vital Hubspot contact creation failed.

New behavior: Treat Hubspot contact creation as non-vital. If a vendor email is missing, log a message and skip Hubspot creation. If email is present and Hubspot contact creation fails, log a message without returning overall vendor creation error to user.