### PR TITLE
fix hydration error with Back button

### DIFF
--- a/frontend/src/components/ui/BackButton.tsx
+++ b/frontend/src/components/ui/BackButton.tsx
@@ -1,27 +1,30 @@
 "use client";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Button from "@mui/material/Button";
+import { useEffect, useState } from "react";
 
 export default function BackButton() {
   const router = useRouter();
-  const referrer = typeof document !== 'undefined' ? document.referrer : null; // Get the referrer (previous page)
-  const backUrl = referrer ? referrer : '/';
+  const searchParams = useSearchParams();
+  const [canGoBack, setCanGoBack] = useState(false);
+
+  useEffect(() => {
+    setCanGoBack(window.history.length > 1);
+  }, []);
 
   const handleBack = () => {
-    // If there's a referrer, use the browser's back action
-    if (referrer) {
+    if (canGoBack) {
       router.back();
     } else {
-      // If no referrer, navigate to the directory directly
-      router.push(backUrl);
+      // If no history, reconstruct a useful fallback
+      const fallback = `/${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
+      router.push(fallback);
     }
   };
 
-  const backButtonText = referrer ? '← Back' : '← Back to Directory';
-
   return (
-    <Button variant="text" onClick={handleBack} color='secondary'>
-      {backButtonText}
+    <Button variant="text" onClick={handleBack} color="secondary">
+      {canGoBack ? "← Back" : "← Back to Directory"}
     </Button>
   );
 }


### PR DESCRIPTION
The Back button was causing hydration errors and misleading behavior in new tabs or direct visits. This PR fixes both issues by replacing unreliable document.referrer checks with a client-only history check.

Problem

- Hydration error: document.referrer was evaluated at render time.
  - Server rendered "← Back to Directory".
  - Client sometimes rendered "← Back".
  - Caused hydration mismatch warnings, mostly in new tabs.

- Broken navigation: In new tabs or bookmarks, referrer was empty.
  - Button showed "← Back" but router.back() did nothing.
  - Misled users and broke navigation flow.

Fix
- Use window.history.length (via useEffect) to detect if back navigation is possible.
- If history exists → router.back().
- Otherwise → router.push("/").
- Button label updates accordingly:
  - "← Back" if history exists.
  - "← Back to Directory" otherwise.

Impact
- 🚫 No more hydration warnings.
- ✅ Back button works reliably in all cases (navigation, new tab, bookmarks).
- ✅ Prevents misleading “Back” label when no history exists.