### PR TITLE
Fix bugs with vendor photo upload

### DIFF
--- a/frontend/src/features/profile/dashboard/components/Section.tsx
+++ b/frontend/src/features/profile/dashboard/components/Section.tsx
@@ -223,7 +223,7 @@ export const SECTIONS: Section[] = [
 
       return {
         isValid: true,
-        isComplete: hasCoverImage && formData.cover_image?.credits !== null,
+        isComplete: hasCoverImage,
         isEmpty: !hasCoverImage,
         errors: {
           cover_image: creditError

--- a/frontend/src/lib/auth/serverAuth.ts
+++ b/frontend/src/lib/auth/serverAuth.ts
@@ -15,7 +15,7 @@ export async function requireAuth() {
 
 export async function requireVendorAccess(vendorSlug: string, user: { id: string }, supabase: SupabaseClient) {
   // Get vendor
-  let vendorQuery = supabase
+  const vendorQuery = supabase
     .from('vendors')
     .select('id, slug');
 

--- a/frontend/src/lib/auth/serverAuth.ts
+++ b/frontend/src/lib/auth/serverAuth.ts
@@ -1,6 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
-import { shouldIncludeTestVendors } from '@/lib/env/env';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 export async function requireAuth() {

--- a/frontend/src/lib/auth/serverAuth.ts
+++ b/frontend/src/lib/auth/serverAuth.ts
@@ -20,10 +20,6 @@ export async function requireVendorAccess(vendorSlug: string, user: { id: string
     .from('vendors')
     .select('id, slug');
 
-  if (!shouldIncludeTestVendors()) {
-    vendorQuery = vendorQuery.not('id', 'like', 'TEST-%');
-  }
-
   const { data: vendor, error: vendorError } = await vendorQuery
     .eq('slug', vendorSlug)
     .single();
@@ -32,7 +28,6 @@ export async function requireVendorAccess(vendorSlug: string, user: { id: string
     console.error("Vendor not found for slug:", vendorSlug, vendorError);
     return { vendor: null, error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
   }
-
 
   // Check if admin
   const { data: profile } = await supabase

--- a/frontend/src/lib/images/vendorMediaHelper.ts
+++ b/frontend/src/lib/images/vendorMediaHelper.ts
@@ -1,14 +1,6 @@
 import type { VendorMediaForm } from '@/types/vendorMedia';
 import type { VendorMediaMutation } from '@/types/vendorMedia';
 
-// Deletes should always execute first. A vendor can only have one photo, so
-// this order prevents the vendor from temporarily having 2 photos
-const MUTATION_ORDER: Record<VendorMediaMutation['operation'], number> = {
-  delete: 0,
-  update: 1,
-  create: 2,
-};
-
 export function deriveMediaMutations(
   draftImages: VendorMediaForm[],
   existingRows: { id: string, media_url: string }[],
@@ -18,6 +10,16 @@ export function deriveMediaMutations(
   console.debug("Deriving media mutations...");
   console.debug("Draft images:", draftImages);
   console.debug("Existing DB rows:", existingRows);
+
+  // Rows in the DB that are no longer in the draft → delete first to avoid violating unique constraints
+  const draftIds = new Set(draftImages.map(i => i.id).filter(Boolean));
+  const draftUrls = new Set(draftImages.map(i => i.media_url));
+  for (const existing of existingRows) {
+    if (!draftIds.has(existing.id) && !draftUrls.has(existing.media_url)) {
+      mutations.push({ operation: 'delete', id: existing.id, media_url: existing.media_url });
+    }
+  }
+
   // Rows in the draft with an id → update if changed, skip if same
   for (const draftImage of draftImages) {
     if (draftImage.id) {
@@ -38,16 +40,5 @@ export function deriveMediaMutations(
     }
   }
 
-  // Rows in the DB that are no longer in the draft → delete
-  const draftIds = new Set(draftImages.map(i => i.id).filter(Boolean));
-  const draftUrls = new Set(draftImages.map(i => i.media_url));
-  for (const existing of existingRows) {
-    if (!draftIds.has(existing.id) && !draftUrls.has(existing.media_url)) {
-      mutations.push({ operation: 'delete', id: existing.id, media_url: existing.media_url });
-    }
-  }
-
-  return mutations.sort(
-    (a, b) => MUTATION_ORDER[a.operation] - MUTATION_ORDER[b.operation]
-  );
+  return mutations;
 }

--- a/frontend/src/lib/images/vendorMediaHelper.ts
+++ b/frontend/src/lib/images/vendorMediaHelper.ts
@@ -1,6 +1,14 @@
 import type { VendorMediaForm } from '@/types/vendorMedia';
 import type { VendorMediaMutation } from '@/types/vendorMedia';
 
+// Deletes should always execute first. A vendor can only have one photo, so
+// this order prevents the vendor from temporarily having 2 photos
+const MUTATION_ORDER: Record<VendorMediaMutation['operation'], number> = {
+  delete: 0,
+  update: 1,
+  create: 2,
+};
+
 export function deriveMediaMutations(
   draftImages: VendorMediaForm[],
   existingRows: { id: string, media_url: string }[],
@@ -39,5 +47,7 @@ export function deriveMediaMutations(
     }
   }
 
-  return mutations;
+  return mutations.sort(
+    (a, b) => MUTATION_ORDER[a.operation] - MUTATION_ORDER[b.operation]
+  );
 }


### PR DESCRIPTION
Bug: When changing a photo using the vendor form, the new photo doesn't upload to `vendor_media` and `vendor`, though it's present in `drafts` and R2 storage. 

RC: Order of vendor_media operations has the `create` happening before `delete`. But we can't add a new photo before deleting the old one, because this violates our current constraint that each vendor has up to 1 photo

Fix: Sort vendor_media operations so that deletes are first

Other small fixes:
- Allow test vendors to update their info in prod
- Mark photo section as complete if there's a photo (before, it's only complete if it has a photo and credit)