### PR TITLE
Fix VendorFeedbackPopup never displaying

### DIFF
--- a/frontend/src/features/contact/components/VendorFeedbackPopup.tsx
+++ b/frontend/src/features/contact/components/VendorFeedbackPopup.tsx
@@ -29,20 +29,19 @@ const NO_FEEDBACK_TEXT = "No issues";
 export const VendorFeedbackPopup = ({
   vendorId,
   businessName,
-  triggerText,
   trigger,
   onDismiss
 }: VendorFeedbackPopupProps) => {
   const [open, setOpen] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
 
-    return trigger && localStorage.getItem(STORAGE_KEY) !== "true";
+    return trigger && sessionStorage.getItem(STORAGE_KEY) !== "true";
   })
   const [comment, setComment] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
 
   const handleClose = () => {
-    localStorage.setItem(STORAGE_KEY, "true");
+    sessionStorage.setItem(STORAGE_KEY, "true");
     setOpen(false);
     setStatus("idle");
     setComment("");
@@ -54,7 +53,7 @@ export const VendorFeedbackPopup = ({
     const success: boolean = await submitVendorFeedback(vendorId, businessName, comment);
     if (success) {
       setStatus("success");
-      localStorage.setItem(STORAGE_KEY, "true");
+      sessionStorage.setItem(STORAGE_KEY, "true");
       setTimeout(() => {
         setOpen(false);
         onDismiss?.();
@@ -72,23 +71,18 @@ export const VendorFeedbackPopup = ({
   return (
     <Dialog open={open} onClose={handleNothingWrong} maxWidth="xs" fullWidth>
       <DialogTitle sx={{ position: "relative", paddingRight: "40px" }}>
-        {status === "success" ? "Thank you!" : "How was your experience?"}
+        {status === "success" ? "Thank you!" : "Anything we can improve?"}
       </DialogTitle>
 
       <DialogContent>
         {status === "success" ? (
           <Typography color="text.secondary">
-            Your feedback helps us improve our site. We appreciate it!
+            Your feedback helps us improve our site.
           </Typography>
         ) : (
           <>
-            {triggerText &&
-              <Typography color="text.secondary" sx={{ mb: 2 }}>
-                {triggerText}
-              </Typography>
-            }
             <Typography color="text.secondary" sx={{ mb: 2 }}>
-              Is there anything that was confusing or could be improved?
+              Let us know if something went wrong, or if you have any suggestions.
             </Typography>
             <TextField
               fullWidth

--- a/frontend/src/features/profile/dashboard/components/VendorEditProfile.tsx
+++ b/frontend/src/features/profile/dashboard/components/VendorEditProfile.tsx
@@ -315,13 +315,14 @@ export default function VendorEditProfile({ vendor, tags, userId }: VendorEditPr
         onKeepEditing={() => setShowUnsavedModal(false)}
         onDiscardChanges={handleDiscardChanges}
       />
-      <VendorFeedbackPopup
-        vendorId={vendor.id}
-        businessName={vendor.business_name || ''}
-        triggerText={"Your profile has been updated."}
-        trigger={feedbackTriggered}
-        onDismiss={() => setFeedbackTriggered(false)}
-      />
+      {feedbackTriggered && (
+        <VendorFeedbackPopup
+          vendorId={vendor.id}
+          businessName={vendor.business_name || ''}
+          trigger={feedbackTriggered}
+          onDismiss={() => setFeedbackTriggered(false)}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
The feedback popup was never shown after a vendor published their profile.

Bug: `VendorFeedbackPopup` was always mounted in the JSX, so its `open` state lazy initializer ran on page load when `feedbackTriggered` was `false`. Subsequent changes to the prop had no effect.

Fix: Conditionally render the popup only when `feedbackTriggered` is `true`, so the lazy initializer runs after the trigger is set and correctly opens the dialog.

Also changed:
- Switched from `localStorage` to `sessionStorage` so the popup shows once per session rather than once ever
- adjust wording of the pop up

<img width="852" height="547" alt="Screenshot 2026-04-14 at 1 51 13 PM" src="https://github.com/user-attachments/assets/fc7a1597-865d-477a-9ae1-c901c0cf7d5b" />
