### PR TITLE
chore: complete image migration from Supabase to Cloudflare R2

### DIFF
--- a/frontend/scripts/cleanup-image-migration.js
+++ b/frontend/scripts/cleanup-image-migration.js
@@ -1,0 +1,210 @@
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { writeFileSync } from 'fs';
+import { URL_MIGRATION_MAP } from '../src/lib/directory/images.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+config({ path: join(__dirname, '..', '.env') });
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const SUPABASE_URL_PREFIX = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET;
+const NEXT_APP_URL = process.env.NEXT_PUBLIC_APP_URL;
+
+// ─── Revalidation ─────────────────────────────────────────────────────────────
+
+async function revalidateVendor(slug) {
+  if (!NEXT_APP_URL || !REVALIDATE_SECRET) {
+    console.warn('   ⚠️  NEXT_PUBLIC_APP_URL or REVALIDATE_SECRET not set — skipping revalidation');
+    return;
+  }
+  try {
+    const res = await fetch(`${NEXT_APP_URL}/api/revalidate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${REVALIDATE_SECRET}`,
+      },
+      body: JSON.stringify({ slug }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    console.log(`   🔄 Revalidated vendor: ${slug}`);
+  } catch (err) {
+    console.warn(`   ⚠️  Revalidation failed for ${slug}:`, err.message);
+  }
+}
+
+async function revalidateAllVendors() {
+  if (!NEXT_APP_URL || !REVALIDATE_SECRET) {
+    console.warn('   ⚠️  NEXT_PUBLIC_APP_URL or REVALIDATE_SECRET not set — skipping revalidation');
+    return;
+  }
+  try {
+    const res = await fetch(`${NEXT_APP_URL}/api/revalidate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${REVALIDATE_SECRET}`,
+      },
+      body: JSON.stringify({}),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    console.log('   🔄 Revalidated all-vendors tag');
+  } catch (err) {
+    console.warn('   ⚠️  Revalidation failed for all-vendors:', err.message);
+  }
+}
+
+async function migrateVendorMedia() {
+  console.log('\n📋 Migrating vendor_media.media_url...');
+  const affectedSlugs = new Set();
+
+  const { data: rows, error } = await supabase
+    .from('vendor_media')
+    .select('id, media_url')
+    .like('media_url', `${SUPABASE_URL_PREFIX}%`);
+
+  if (error) throw error;
+  console.log(`   Found ${rows.length} Supabase URLs`);
+
+  writeFileSync(`backup-vendor-media-${Date.now()}.json`, JSON.stringify(rows, null, 2));
+
+  let ok = 0, fail = 0, skipped = 0;
+
+  for (const row of rows) {
+    const r2Url = URL_MIGRATION_MAP.get(row.media_url);
+
+    if (!r2Url) {
+      console.warn(`   ⚠️  No mapping found for id=${row.id}: ${row.media_url}`);
+      skipped++;
+      continue;
+    }
+
+    console.log(`   ${row.media_url}\n   → ${r2Url}`);
+
+    if (!DRY_RUN) {
+      const { error: updateError } = await supabase
+        .from('vendor_media')
+        .update({ media_url: r2Url })
+        .eq('id', row.id);
+
+      if (updateError) {
+        console.error(`   ❌ Failed (id=${row.id}):`, updateError.message);
+        fail++;
+        continue;
+      }
+    }
+    const slug = row.vendors?.slug;
+    if (slug) affectedSlugs.add(slug);
+
+    ok++;
+  }
+
+  return { ok, fail, skipped, affectedSlugs };
+}
+
+async function migrateCoverImages() {
+  console.log('\n📋 Migrating vendors.cover_image...');
+
+  const affectedSlugs = new Set();
+  const { data: rows, error } = await supabase
+    .from('vendors')
+    .select('id, business_name, slug, cover_image')
+    .like('cover_image', `${SUPABASE_URL_PREFIX}%`);
+
+  if (error) throw error;
+  console.log(`   Found ${rows.length} Supabase URLs`);
+
+  writeFileSync(`backup-vendors-${Date.now()}.json`, JSON.stringify(rows, null, 2));
+
+  let ok = 0, fail = 0, skipped = 0;
+
+  for (const row of rows) {
+    const r2Url = URL_MIGRATION_MAP.get(row.cover_image);
+
+    if (!r2Url) {
+      console.warn(`   ⚠️  No mapping found for ${row.business_name}: ${row.cover_image}`);
+      skipped++;
+      continue;
+    }
+
+    console.log(`   ${row.business_name}: ${row.cover_image}\n   → ${r2Url}`);
+
+    if (!DRY_RUN) {
+      const { error: updateError } = await supabase
+        .from('vendors')
+        .update({ cover_image: r2Url })
+        .eq('id', row.id);
+
+      if (updateError) {
+        console.error(`   ❌ Failed (id=${row.id}):`, updateError.message);
+        fail++;
+        continue;
+      }
+
+    }
+    const slug = row.vendors?.slug;
+    if (slug) affectedSlugs.add(slug);
+
+    ok++;
+  }
+
+  return { ok, fail, skipped, affectedSlugs };
+}
+
+async function verifyStragglers() {
+  console.log('\n🔍 Checking for remaining Supabase URLs...');
+
+  const [{ data: mediaRows }, { data: vendorRows }] = await Promise.all([
+    supabase.from('vendor_media').select('id, media_url').like('media_url', `${SUPABASE_URL_PREFIX}%`),
+    supabase.from('vendors').select('id, business_name, cover_image').like('cover_image', `${SUPABASE_URL_PREFIX}%`),
+  ]);
+
+  if (mediaRows?.length) {
+    console.warn(`⚠️  ${mediaRows.length} stragglers in vendor_media:`);
+    mediaRows.forEach(r => console.warn(`   id=${r.id} — ${r.media_url}`));
+  }
+  if (vendorRows?.length) {
+    console.warn(`⚠️  ${vendorRows.length} stragglers in vendors.cover_image:`);
+    vendorRows.forEach(r => console.warn(`   id=${r.id} (${r.business_name}) — ${r.cover_image}`));
+  }
+  if (!mediaRows?.length && !vendorRows?.length) {
+    console.log('✅ No Supabase URLs remaining — safe to remove the migration map!');
+  }
+}
+
+async function main() {
+  console.log(`🚀 Starting migration${DRY_RUN ? ' (DRY RUN)' : ''}...`);
+
+  const mediaResult = await migrateVendorMedia();
+  const vendorResult = await migrateCoverImages();
+
+  console.log('\n🎉 Done!');
+  console.log(`   vendor_media:  ✅ ${mediaResult.ok}  ❌ ${mediaResult.fail}  ⚠️  ${mediaResult.skipped} unmapped`);
+  console.log(`   vendors:       ✅ ${vendorResult.ok}  ❌ ${vendorResult.fail}  ⚠️  ${vendorResult.skipped} unmapped`);
+
+  if (!DRY_RUN) {
+    await verifyStragglers();
+    console.log('\n🔄 Revalidating affected vendors...');
+    const allSlugs = new Set([...mediaResult.affectedSlugs, ...vendorResult.affectedSlugs]);
+    for (const slug of allSlugs) {
+      await revalidateVendor(slug);
+    }
+    await revalidateAllVendors();
+  }
+}
+
+main().catch(err => {
+  console.error('💥 Fatal:', err);
+  process.exit(1);
+});

--- a/frontend/src/lib/directory/images.ts
+++ b/frontend/src/lib/directory/images.ts
@@ -2,255 +2,6 @@ import { BackendVendor } from "@/types/vendor";
 import { VendorMedia } from "@/types/vendorMedia";
 import { isAllowedPrefix } from "@/lib/images/prefixes";
 
-const URL_MIGRATION_MAP = new Map([
-  // [
-  //   "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_jane_c_cover_photo.jpeg",
-  //   "https://images.asianweddingmakeup.com/test-portraits/hmua_jane_c_cover_photo.jpg"
-  // ],
-  ["https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_lindsey_ariel_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_lyndsey_ariel_pozo_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmau_lyndsey_ariel_pozo_cover_photo2.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_lyndsey_ariel_pozo_cover_photo2.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmau_lyndsey_ariel_pozo_cover_photo3.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_lyndsey_ariel_pozo_cover_photo3.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmau_lyndsey_ariel_pozo_cover_photo4.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_lyndsey_ariel_pozo_cover_photo4.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmau_lyndsey_ariel_pozo_cover_photo5.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_lyndsey_ariel_pozo_cover_photo5.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmau_lyndsey_ariel_pozo_cover_photo6.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_lyndsey_ariel_pozo_cover_photo6.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmau_mable_pang_cover_photo_2.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_mable_pang_cover_photo_2.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmau_mable_pang_cover_photo_3.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_mable_pang_cover_photo_3.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmau_mable_pang_cover_photo_4.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_mable_pang_cover_photo_4.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmua_jenny_nguyen_cover_image_2.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_jenny_nguyen_cover_image_2.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmua_jenny_nguyen_cover_image_3.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_jenny_nguyen_cover_image_3.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmua_jenny_nguyen_cover_image_4.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_jenny_nguyen_cover_image_4.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmua_jenny_nguyen_cover_image_5.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_jenny_nguyen_cover_image_5.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_jenny_nguyen_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_jenny_nguyen_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_mable_pang_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_mable_pang_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_aimee_artistry_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_aimee_artistry_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_ceo_beauty_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_ceo_beauty_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_diemangie_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_diemangie_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_drake_artistry_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_drake_artistry_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_emely_j_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_emely_j_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_j_tan_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_j_tan_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_jennifer_le_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_jennifer_le_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmua_jenny_le_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_jenny_le_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_julie_dy_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_julie_dy_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_chien_buffle_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_chien_buffle_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_hera_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_hera_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_joie_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_joie_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_linda_independent_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_linda_independent_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_love_notes_by_june_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_love_notes_by_june_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_luong_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_luong_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_lynn_yee_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_lynn_yee_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_primed_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_primed_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_priscilla_freire_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_priscilla_freire_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_pure_makeup_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_pure_makeup_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_vivi_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_vivi_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_xiomara_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_xiomara_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_all_brides_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_all_brides_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_coco_tsang_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_coco_tsang_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_cp_wedding_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_cp_wedding_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_darima_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_darima_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_ford_beauty_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_ford_beauty_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_grace_lin_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_grace_lin_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmua_jen_lim_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_jen_lim_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_jenny_luu_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_jenny_luu_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmua_kelly_tran_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_kelly_tran_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_michelle_valentine_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_michelle_valentine_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmua_pink_palette_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_pink_palette_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos//hmua_refined_beauty_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_refined_beauty_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_rhia_amio_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_rhia_amio_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_teresa_snowball_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_teresa_snowball_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_glitter_glam_sarah_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_glitter_glam_sarah_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_kathy_kho_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_kathy_kho_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_khloe_nguyen_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_khloe_nguyen_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_krimse_cover_photo_1.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_krimse_cover_photo_1.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_m_villanueva_cover_photo.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_m_villanueva_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_mai_tokioka_cover_photo_2.jpeg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_mai_tokioka_cover_photo_2.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_serena_park_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_serena_park_cover_photo.jpg"
-  ],
-  [
-    "https://xbsnelpjukudknfvmnnj.supabase.co/storage/v1/object/public/hmua-cover-photos/hmua_shannon_le_cover_photo.jpg",
-    "https://images.asianweddingmakeup.com/test-portraits/hmua_shannon_le_cover_photo.jpg"
-  ]
-]);
-
-export function getMigratedUrl(originalUrl: string): string {
-  // Check if URL is in our migration allowlist
-  const migrated = URL_MIGRATION_MAP.get(originalUrl);
-
-  if (migrated) {
-    return migrated;
-  }
-  // Return original URL if not migrated yet
-  return originalUrl;
-}
-
 export function processVendorImages(
   vendor: BackendVendor,
 ): VendorMedia[] {
@@ -280,7 +31,7 @@ export function processVendorImages(
  * Returns null if URL has unsupported prefix
  */
 function createVendorMedia(
-  originalUrl: string,
+  url: string,
   vendorId: string,
   overrides: {
     id: string;
@@ -289,12 +40,9 @@ function createVendorMedia(
     credits?: string | null;
   }
 ): VendorMedia | null {
-  if (!isAllowedPrefix(originalUrl)) {
+  if (!isAllowedPrefix(url)) {
     return null;
   }
-
-  const migratedUrl = getMigratedUrl(originalUrl);
-  const source = migratedUrl !== originalUrl ? 'r2' : 'supabase';
 
   console.debug(`overrides:`, overrides);
   return {
@@ -303,8 +51,6 @@ function createVendorMedia(
     is_featured: overrides.is_featured ?? false,
     consent_given: overrides.consent_given ?? false,
     credits: overrides.credits ?? null,
-    media_url: migratedUrl,
-    original_url: originalUrl,
-    source: source,
+    media_url: url
   };
 }

--- a/frontend/src/lib/images/prefixes.ts
+++ b/frontend/src/lib/images/prefixes.ts
@@ -2,11 +2,6 @@ import { shouldIncludeTestVendors } from "@/lib/env/env";
 
 const prefixes: string[] = [];
 
-// add supabase storage url (deprecated)
-if (process.env.NEXT_PUBLIC_SUPABASE_IMAGE_URL) {
-  prefixes.push(process.env.NEXT_PUBLIC_SUPABASE_IMAGE_URL);
-}
-
 // add cloudflare r2 url
 if (process.env.NEXT_PUBLIC_R2_PUBLIC_URL) {
   prefixes.push(process.env.NEXT_PUBLIC_R2_PUBLIC_URL);

--- a/frontend/src/types/vendorMedia.ts
+++ b/frontend/src/types/vendorMedia.ts
@@ -9,10 +9,7 @@ export type VendorMedia = Pick<BackendVendorMedia, 'id'
   | 'media_url'
   | 'is_featured'
   | 'vendor_id'
-> & {
-  source: string,
-  original_url: string,
-}
+>;
 
 export type VendorMediaDraft = VendorMediaBase & {
   id?: never; // Explicitly not persisted yet


### PR DESCRIPTION
This finishes the migration of all vendor images from Supabase storage to Cloudflare R2, and removes the interim fallback that was keeping both systems in play. 

## Previous Solution
The images were moved from Supabase storage to Cloudflare R2 as an emergency measure, since we hit the Supabase usage limits for storage.

However, the db data (`vendor_media` and `vendor` tables) wasn't updated with the new links. We used an interim `URL_MIGRATION_MAP` to hardcode the migration state directly in the application layer until we could finish the migration.

## Changes
I've tested and run the migration script already. This PR commits the script and cleans up the interim fallback.

**Migration script** (`scripts/cleanup-image-migration.js`)
- Uses `URL_MIGRATION_MAP` as the source of truth to update `vendor_media.media_url` and `vendors.cover_image` in-place
- Calls `/api/revalidate` for each affected vendor slug after updates, then fires a final `all-vendors` revalidation
- Runs a straggler check at the end to confirm no Supabase URLs remain


**Cleanup**
- Removed `URL_MIGRATION_MAP` and `getMigratedUrl`
- Removed `source` and `original_url` fields from `VendorMedia` construction. Code search shows this is safe.

## Testing

- Ran script with `--dry-run` first to verify all URLs had mappings
- Ran for real; straggler check confirmed zero remaining Supabase URLs
- Checked Supabase tables (vendor, vendor_media, vendor_drafts) to make sure there are no more Supabase URLs
- Checked prod source code to verify vendor pages and directory pages do not use Supabase URLs