### PR TITLE
Remove inefficiencies from AuthContext

### DIFF
--- a/frontend/src/app/(public)/login/page.tsx
+++ b/frontend/src/app/(public)/login/page.tsx
@@ -1,3 +1,4 @@
+import LoadingPage from "@/components/layouts/LoadingPage";
 import UserLogin from "@/features/login/components/UserLogin";
 import { Metadata } from "next";
 import { Suspense } from "react";
@@ -13,7 +14,7 @@ export const metadata: Metadata = {
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<LoadingPage />}>
       <UserLogin />
     </Suspense>
   );

--- a/frontend/src/app/(public)/vendors/[slug]/page.tsx
+++ b/frontend/src/app/(public)/vendors/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { LocationBreadcrumbs } from '@/components/layouts/LocationBreadcrumbs';
 import Container from '@mui/material/Container';
 import { getDisplayNameWithoutType } from '@/lib/location/locationNames';
 import { generateBreadcrumbSlugs } from '@/lib/location/locationSlugs';
+import LoadingPage from '@/components/layouts/LoadingPage';
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
@@ -125,7 +126,7 @@ export default async function VendorPage({ params }: PageProps) {
         />
         {/* ... */}
       </section>
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<LoadingPage />}>
         <BackButton />
         <Container sx={{ py: 4 }}>
           <LocationBreadcrumbs breadcrumbs={breadcrumbs} />

--- a/frontend/src/app/(vendor)/partner/claim/page.tsx
+++ b/frontend/src/app/(vendor)/partner/claim/page.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react";
-import CircularProgress from "@mui/material/CircularProgress";
 import type { Metadata } from "next";
 import Box from "@mui/system/Box";
 import VendorClaimContent from "@/features/vendorClaim/components/VendorClaimContent";
+import LoadingPage from "@/components/layouts/LoadingPage";
 
 export const metadata: Metadata = {
   title: "Claim your profile | Asian Wedding Makeup",
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 
 export default function VendorClaimPage() {
   return (
-    <Suspense fallback={<CircularProgress size={28} />}>
+    <Suspense fallback={<LoadingPage />}>
       <Box sx={{ bgcolor: "background.back", minHeight: "100vh", display: "flex" }}>
         <VendorClaimContent />
       </Box>

--- a/frontend/src/app/(vendor)/partner/login/page.tsx
+++ b/frontend/src/app/(vendor)/partner/login/page.tsx
@@ -1,3 +1,4 @@
+import LoadingPage from '@/components/layouts/LoadingPage';
 import VendorLogin from '@/features/login/components/VendorLogin';
 import { Metadata } from 'next';
 import { Suspense } from 'react';
@@ -13,7 +14,7 @@ export const metadata: Metadata = {
 
 export default function VendorLoginPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<LoadingPage />}>
       <VendorLogin />
     </Suspense>
   );

--- a/frontend/src/components/layouts/LoadingPage.tsx
+++ b/frontend/src/components/layouts/LoadingPage.tsx
@@ -1,0 +1,10 @@
+import CircularProgress from "@mui/material/CircularProgress";
+import Box from "@mui/material/Box";
+
+export default function LoadingPage() {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '80vh' }}>
+      <CircularProgress />
+    </Box>
+  );
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import type { SupabaseClient, User, Session } from '@supabase/supabase-js';
+import type { SupabaseClient, User } from '@supabase/supabase-js';
 import { UserRole, getUserRole } from '@/lib/auth/userRole';
 
 type AuthContextType = {
   user: User | null;
-  session: Session | null;
   isLoading: boolean;
   isLoggedIn: boolean;
   supabase: SupabaseClient;
-  refreshSession: () => Promise<void>;
   role: UserRole;
   vendorId: string | null;
   isRoleLoading: boolean;
@@ -21,7 +19,6 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
-  const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [role, setRole] = useState<UserRole>(UserRole.USER);
   const [vendorId, setVendorId] = useState<string | null>(null);
@@ -60,32 +57,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     checkUserRole();
   }, [user, supabase]);
 
-  const refreshSession = useCallback(async () => {
-    const { data } = await supabase.auth.getSession();
-    setSession(data.session);
-    setUser(data.session?.user || null);
-    setIsLoading(false);
-  }, [supabase]);
-
   useEffect(() => {
-    refreshSession();
-
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session);
       setUser(session?.user || null);
       setIsLoading(false);
     });
 
     return () => subscription.unsubscribe();
-  }, [refreshSession, supabase.auth]);
+  }, [supabase.auth]);
 
   const value = {
     user,
-    session,
     isLoading,
-    isLoggedIn: !!session,
+    isLoggedIn: !!user,
     supabase,
-    refreshSession,
     role,
     vendorId,
     isRoleLoading,

--- a/frontend/src/features/directory/components/Directory.tsx
+++ b/frontend/src/features/directory/components/Directory.tsx
@@ -3,7 +3,7 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import { Vendor } from '@/types/vendor';
 import FilterableVendorTable from './FilterableVendorTable';
-import { Suspense, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getFavoriteVendorIds } from '@/features/favorites/api/getUserFavorites';
 import { usePathname } from 'next/navigation';
 import { LocationResult } from '@/types/location';
@@ -51,15 +51,13 @@ export function Directory({ vendors, tags, selectedLocation }: DirectoryProps) {
       <Typography>
         Find talented makeup artists and hair stylists who are recommended by the Asian diaspora community.
       </Typography>
-      <Suspense fallback={<div>Loading...</div>}>
-        <FilterableVendorTable
-          vendors={vendors}
-          favoriteVendorIds={favoriteVendorIds}
-          tags={tags}
-          preselectedLocation={selectedLocation}
-          useLocationPages={!!selectedLocation}
-        />
-      </Suspense>
+      <FilterableVendorTable
+        vendors={vendors}
+        favoriteVendorIds={favoriteVendorIds}
+        tags={tags}
+        preselectedLocation={selectedLocation}
+        useLocationPages={!!selectedLocation}
+      />
     </Container>
   );
 }

--- a/frontend/src/features/directory/components/FilterableVendorTable.tsx
+++ b/frontend/src/features/directory/components/FilterableVendorTable.tsx
@@ -24,6 +24,7 @@ import { ResultsHeader } from './tableLayout/ResultsHeader';
 import { URLFiltersProvider } from '@/contexts/URLFiltersContext';
 import { useURLFilters } from '@/hooks/useURLFilters';
 import { FilterTags } from '@/lib/directory/filterTags';
+import LoadingPage from '@/components/layouts/LoadingPage';
 
 const PAGE_SIZE = 12;
 const FILTER_MIN_WIDTH = 240;
@@ -251,7 +252,7 @@ export default function FilterableVendorTable(props: {
   useLocationPages?: boolean,
 }) {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<LoadingPage />}>
       <URLFiltersProvider preservePathname={props.useLocationPages ?? false}>
         <FilterableVendorTableContent
           {...props}

--- a/frontend/src/features/login/api/actions.ts
+++ b/frontend/src/features/login/api/actions.ts
@@ -45,5 +45,9 @@ export async function login(formData: FormData) {
   const isVendorAccount = getUserRole(profile) === UserRole.VENDOR;
 
   revalidatePath('/', 'layout');
-  return { success: true, isVendorAccount };
+  return {
+    success: true, isVendorAccount,
+    accessToken: data.session.access_token,
+    refreshToken: data.session.refresh_token,
+  };
 }

--- a/frontend/src/features/login/components/LoginForm.tsx
+++ b/frontend/src/features/login/components/LoginForm.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { useRouter } from 'next/navigation';
-import { useAuth } from '@/contexts/AuthContext';
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
@@ -22,14 +21,15 @@ import Visibility from "@mui/icons-material/Visibility";
 import ArrowForward from "@mui/icons-material/ArrowForward";
 import Divider from "@mui/material/Divider";
 import CircularProgress from "@mui/material/CircularProgress";
+import { useAuth } from "@/contexts/AuthContext";
 
 export const LoginForm = ({ isVendorLogin, redirectTo }: { isVendorLogin: boolean, redirectTo: string | undefined }) => {
   const { addNotification } = useNotification();
   const router = useRouter();
-  const { refreshSession } = useAuth();
   const [verificationNeeded, setVerificationNeeded] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const { supabase } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -59,9 +59,14 @@ export const LoginForm = ({ isVendorLogin, redirectTo }: { isVendorLogin: boolea
         ? redirectTo
         : (isVendorAccount ? '/partner/dashboard' : '/');
 
-      // Refresh client-side auth state so the navbar and other client UI update
-      refreshSession().catch((e) => {
-        console.debug('refreshSession failed after login:', e);
+      if (!result.accessToken || !result.refreshToken) {
+        router.push(redirectPath);
+        return;
+      }
+
+      await supabase.auth.setSession({
+        access_token: result.accessToken,
+        refresh_token: result.refreshToken,
       });
       router.push(redirectPath);
 


### PR DESCRIPTION
AuthContext exposed `session` state (never used) and `refreshSession` callback (used in one place). The session state caused two unnecessary re-renders on every auth event:

1. `setSession(session)` triggered a render
2. `setUser(session?.user)` triggered another render

This PR removes sessions from the AuthContext and adds the session management directly to LoginForm.

Changes:
- Simplify `AuthContext` by removing unused session state, and the `refreshSession` pattern that's only used by LoginForm
- Update LoginForm to update session directly
- Create a LoadingPage component to replace the ugly "Loading..." fallback. I noticed this when logging in, but we use it in multiple places