### PR TITLE
[BUG] fix conditional redirect with /signup

### DIFF
--- a/frontend/e2e/smoke/auth.protected.spec.ts
+++ b/frontend/e2e/smoke/auth.protected.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '../fixtures/fixtures';
+
+// eslint-disable-next-line react-hooks/rules-of-hooks
+test.use({ storageState: ({ userWorkerStorageState }, use) => use(userWorkerStorageState) });
+
+test('authenticated user visiting /signup is redirected to directory', async ({ page }) => {
+  await page.goto('/signup');
+  await expect(page).toHaveURL('/');
+});
+
+test('authenticated user can visit /auth/reset-password ', async ({ page }) => {
+  await page.goto('/auth/reset-password');
+  await expect(page.getByLabel('New Password', { exact: true })).toBeVisible();
+  await expect(page.getByLabel('Confirm New Password')).toBeVisible();
+  await expect(page.locator('#newPassword')).toBeVisible();
+  await expect(page.locator('#confirmPassword')).toBeVisible();
+});

--- a/frontend/e2e/smoke/auth.public.spec.ts
+++ b/frontend/e2e/smoke/auth.public.spec.ts
@@ -5,3 +5,15 @@ test('login page renders', async ({ page }) => {
   await expect(page.getByLabel('Email Address')).toBeVisible();
   await expect(page.getByLabel('Password')).toBeVisible();
 });
+
+test('signup page renders', async ({ page }) => {
+  await page.goto('/signup');
+  await expect(page.getByLabel('Email Address')).toBeVisible();
+  await expect(page.locator('#password')).toBeVisible();
+  await expect(page.locator('#confirmPassword')).toBeVisible();
+});
+
+test('unauthenticated user visiting /auth/reset-password gets redirected to /login', async ({ page }) => {
+  await page.goto('/auth/reset-password');
+  await expect(page).toHaveURL('/login');
+});

--- a/frontend/src/features/auth/components/shared/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/components/shared/ResetPasswordPage.tsx
@@ -108,6 +108,7 @@ export function ResetPasswordPage({ loginUrl, isVendorSite }: ResetPasswordPageP
                     fullWidth
                     type={showPassword ? "text" : "password"}
                     label="New Password"
+                    id="newPassword"
                     value={newPassword}
                     onChange={(e) => {
                       setNewPassword(e.target.value);
@@ -135,6 +136,7 @@ export function ResetPasswordPage({ loginUrl, isVendorSite }: ResetPasswordPageP
                     fullWidth
                     type={showConfirmPassword ? "text" : "password"}
                     label="Confirm New Password"
+                    id="confirmPassword"
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                     margin="normal"

--- a/frontend/src/features/auth/components/shared/SignupPage.tsx
+++ b/frontend/src/features/auth/components/shared/SignupPage.tsx
@@ -19,7 +19,7 @@ export function SignupPage({ title, redirectUrl }: SignupPageProps) {
   const { isLoggedIn, isLoading } = useAuth();
 
   useEffect(() => {
-    if (!isLoading && !isLoggedIn) {
+    if (!isLoading && isLoggedIn) {
       router.push(redirectUrl);
     }
   }, [isLoggedIn, isLoading, router, redirectUrl]);

--- a/frontend/src/lib/supabase/middleware.ts
+++ b/frontend/src/lib/supabase/middleware.ts
@@ -76,7 +76,7 @@ export async function updateSession(request: NextRequest) {
       url.searchParams.delete('redirectTo');
       return NextResponse.redirect(url);
     }
-    if (request.nextUrl.pathname === '/login') {
+    if (request.nextUrl.pathname === '/login' || request.nextUrl.pathname === '/signup') {
       const url = request.nextUrl.clone();
       url.pathname = '/';
       url.searchParams.delete('redirectTo');


### PR DESCRIPTION
Fix a bug with /signup introduced by #259 , where the redirect condition was reversed. I've double checked the PR again to make sure there aren't similar bugs. I've also added new tests for /signup and /reset-password