### PR TITLE
[BUG] Fix user role bug in AuthContext

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -59,6 +59,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const { data: { subscription } } = supabaseBrowserClient.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        setIsRoleLoading(true);
+      }
       setUser(session?.user || null);
       setIsLoading(false);
     });


### PR DESCRIPTION
## Bug
When a user with an existing session loaded the page, `isRoleLoading` would remain false on mount. This created a window where both `isLoading` and `isRoleLoading` were false, but role was still the default `USER`. Role-gated pages would redirect before the profile fetch completed.

This was a latent bug exposed when removing inefficient `session` usage in #260  

## Fix
Set `isRoleLoading=true` in the `onAuthStateChange` callback whenever a session exists. This ensures `isRoleLoading` stays true until the profile fetch completes, preventing premature redirects on role-gated pages.

