### PR TITLE
[BUG] prevent role re-fetch and form reset on token refresh

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -25,8 +25,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [vendorId, setVendorId] = useState<string | null>(null);
   const [isRoleLoading, setIsRoleLoading] = useState(true);
 
+  // Listen for auth state changes
+  useEffect(() => {
+    const { data: { subscription } } = supabaseBrowserClient.auth.onAuthStateChange((_event, session) => {
+      setUser(prev => {
+        if (prev?.id === session?.user?.id) return prev; // same user, keep same reference
+        return session?.user || null;
+      });
+      setIsLoading(false);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
   // Check role and vendor status whenever user changes
   useEffect(() => {
+    if (isLoading) return; // waits for auth to settle before running
+
     const checkUserRole = async () => {
       if (!user) {
         setRole(UserRole.USER);
@@ -55,19 +70,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     checkUserRole();
-  }, [user]);
+  }, [user, isLoading]);
 
-  useEffect(() => {
-    const { data: { subscription } } = supabaseBrowserClient.auth.onAuthStateChange((_event, session) => {
-      if (session?.user) {
-        setIsRoleLoading(true);
-      }
-      setUser(session?.user || null);
-      setIsLoading(false);
-    });
-
-    return () => subscription.unsubscribe();
-  }, []);
 
   const value = {
     user,


### PR DESCRIPTION
Follows up on the fix in #267 which set `isRoleLoading=true` in `onAuthStateChange` whenever a session existed. That fix prevented premature redirects on role-gated pages, but caused a new issue:
`TOKEN_REFRESHED` events would set `isRoleLoading=true` each time, resetting field state when a user returned to a tab (e.g. new vendor form gets reset when you move between tabs)

Two changes:
- onAuthStateChange now compares user IDs before updating user state, so TOKEN_REFRESHED no longer causes a re-render cascade
- Role effect now guards on `isLoading` instead of relying on the auth handler to pre-set isRoleLoading, keeping the two effects cleanly decoupled and preventing premature role checks on mount