### PR TITLE
[Bug] Fix getPostBySlug cache key to be slug-specific

### DIFF
--- a/frontend/src/features/blog/api/getBlogPosts.ts
+++ b/frontend/src/features/blog/api/getBlogPosts.ts
@@ -30,21 +30,21 @@ export async function getAllPosts() {
   }
 }
 
-const _getPostBySlug = unstable_cache(
-  async (slug: string) => {
+const _getPostBySlug = (slug: string) => unstable_cache(
+  async () => {
     const { pageBlogPostCollection } = await graphQLClient.request<GetBlogPostBySlugQuery>(
       GetBlogPostBySlugDocument,
       { slug }
     );
     return pageBlogPostCollection?.items[0] ?? null;
   },
-  ['post-by-slug'],
+  [`post-by-slug-${slug}`],
   { revalidate: 300, tags: ['all-posts'] }
-)
+);
 
 export async function getPostBySlug(slug: string) {
   try {
-    return await _getPostBySlug(slug)
+    return await _getPostBySlug(slug)();
   } catch (err) {
     console.error(`Error fetching post by slug (${slug}):`, err)
     return null

--- a/frontend/src/features/blog/components/SpotlightHeader.tsx
+++ b/frontend/src/features/blog/components/SpotlightHeader.tsx
@@ -13,19 +13,19 @@ const SpotlightHeader = ({ post }: { post: PageBlogPost }) => {
       <Typography variant="h6" paddingBottom={2} align="center">{post.shortDescription}</Typography>
       {post.featuredImage?.url && (
         <Box display="flex" flexDirection="column" alignItems="center" sx={{ width: '100%', mb: 4 }}>
-          <Box sx={{ 
-            position: 'relative', 
-            height: '600px', 
-            width: '100%', 
-            maxWidth: '500px', // Limit width for portrait photos
-            margin: '0 auto' // Center the container
+          <Box sx={{
+            position: 'relative',
+            aspectRatio: '4 / 3',
+            width: '100%',
+            maxHeight: { xs: '400px', md: '600px' },
+            mb: 4
           }}>
             <ContentfulImage
               alt={`Cover Image: ${post.featuredImage.title}`}
               src={post.featuredImage.url}
               fill
               priority
-              sizes="(max-width: 500px) 100vw, 500px"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 800px"
               style={{
                 objectPosition: 'center top', // Focus on the top portion
                 objectFit: 'cover',

--- a/frontend/src/features/blog/components/SpotlightHeader.tsx
+++ b/frontend/src/features/blog/components/SpotlightHeader.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 
 const SpotlightHeader = ({ post }: { post: PageBlogPost }) => {
+  const isLandscape = (post.featuredImage?.width ?? 0) > (post.featuredImage?.height ?? 0)
 
   return (
     <>
@@ -15,10 +16,17 @@ const SpotlightHeader = ({ post }: { post: PageBlogPost }) => {
         <Box display="flex" flexDirection="column" alignItems="center" sx={{ width: '100%', mb: 4 }}>
           <Box sx={{
             position: 'relative',
-            aspectRatio: '4 / 3',
-            width: '100%',
-            maxHeight: { xs: '400px', md: '600px' },
-            mb: 4
+            ...(isLandscape ? {
+              aspectRatio: '4 / 3',
+              width: '100%',
+              maxHeight: { xs: '400px', md: '600px' },
+            } : {
+              height: '600px',
+              width: '100%',
+              maxWidth: '500px',
+              margin: '0 auto',
+            }),
+            mb: 2
           }}>
             <ContentfulImage
               alt={`Cover Image: ${post.featuredImage.title}`}
@@ -32,7 +40,7 @@ const SpotlightHeader = ({ post }: { post: PageBlogPost }) => {
               }}
             />
           </Box>
-        </Box>
+        </Box >
       )}
     </>
   )


### PR DESCRIPTION
We use a cache for checking blog post dates, which determines whether a blog is password-protected

However `unstable_cache` was using a static key `['post-by-slug']` for all slugs, meaning the first slug fetched would be returned for every subsequent call regardless of the actual slug requested.

Changes:
* make the cache key slug-specific to fix password gate
* allow landscape photos for featured spotlight photo
