### PR TITLE
exclude future blog posts from pre-rendering

### DIFF
--- a/frontend/src/app/(public)/blog/[slug]/page.tsx
+++ b/frontend/src/app/(public)/blog/[slug]/page.tsx
@@ -12,9 +12,9 @@ type Props = {
 
 export async function generateStaticParams() {
   const posts = await getAllPosts();
-  return posts.map((post) => ({
-    slug: post?.slug,
-  }));
+  return posts
+    .filter(post => post && new Date(post.publishedDate) <= new Date()) // exclude future posts
+    .map(post => ({ slug: post?.slug }));
 }
 
 // This function runs at build time for paths returned by generateStaticParams


### PR DESCRIPTION
If the blog post is pre-rendered, middleware won't run and redirect. This is fine for published posts but not for future blog posts that are password gated