### PR TITLE
restore landscape sizing for spotlight header

### DIFF
--- a/frontend/src/features/blog/components/SpotlightHeader.tsx
+++ b/frontend/src/features/blog/components/SpotlightHeader.tsx
@@ -26,9 +26,6 @@ const SpotlightHeader = ({ post }: { post: PageBlogPost }) => {
         <Box display="flex" flexDirection="column" alignItems="center" sx={{ width: '100%', mb: 4 }}>
           <Box sx={{
             position: 'relative',
-            height: '600px',
-            maxWidth: '500px',
-            margin: '0 auto',
             ...(isLandscape ? {
               aspectRatio: '4 / 3',
               width: '100%',


### PR DESCRIPTION
Remove photo sizing options reintroduced when merging #276 . This will fix the landscape sizing for our spotlight header, which is currently cut off on the sides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved featured image layout to better accommodate different image orientations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klee97/directory-app/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->