### PR TITLE
add inquiries to supabase for new inquiry lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           # Settings → Secrets and variables → Actions → New repository secret
           NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_LOCAL_PUBLISHABLE_KEY }}
+          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_LOCAL_SECRET_KEY }}
           # Add any other required vars here, e.g:
           # NEXT_PUBLIC_SOME_API_KEY: ${{ secrets.NEXT_PUBLIC_SOME_API_KEY }}
 

--- a/frontend/e2e/inquiries/inquiries.public.spec.ts
+++ b/frontend/e2e/inquiries/inquiries.public.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
 
 /**
  * Runs against the local Supabase instance, which the 'supabase-setup'
@@ -11,6 +12,10 @@ import { test, expect } from '@playwright/test';
 
 const HAIR_TAG_ID = 'e2e00000-0000-0000-0000-000000000001';
 const MAKEUP_TAG_ID = 'e2e00000-0000-0000-0000-000000000003';
+const supabaseAdminClient = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SECRET_KEY!
+);
 
 test.describe('POST /api/inquiries (local Supabase)', () => {
   test('creates a real inquiry row end-to-end', async ({ request }) => {
@@ -42,6 +47,22 @@ test.describe('POST /api/inquiries (local Supabase)', () => {
     const body = await response.json();
     expect(body.ok).toBe(true);
     expect(typeof body.data.id).toBe('string');
+
+    const { data: inquiry, error } = await supabaseAdminClient
+      .from('inquiries')
+      .select('is_test_record, service_tag_ids, bride_first_name, bride_last_name, budget, people_count')
+      .eq('id', body.data.id)
+      .maybeSingle();
+
+    expect(error).toBeNull();
+    expect(inquiry).toMatchObject({
+      is_test_record: true,
+      service_tag_ids: [HAIR_TAG_ID, MAKEUP_TAG_ID],
+      bride_first_name: 'Playwright',
+      bride_last_name: 'Test',
+      budget: 500,
+      people_count: 4,
+    });
   });
 
   test('returns 500 for invalid inquiry, like an unknown vendor_id', async ({ request }) => {
@@ -60,12 +81,12 @@ test.describe('POST /api/inquiries (local Supabase)', () => {
       },
     });
 
-    expect(response.status()).toBe(500);
+    expect(response.status()).toBe(422);
     const body = await response.json();
     expect(body).toEqual({
       ok: false,
-      error: 'Could not save inquiry',
-      code: 'INSERT_FAILED',
+      error: 'Vendor could not be found',
+      code: 'INVALID_VENDOR',
     });
   });
 

--- a/frontend/e2e/inquiries/inquiries.public.spec.ts
+++ b/frontend/e2e/inquiries/inquiries.public.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import { createClient } from '@supabase/supabase-js';
 
 /**
  * Runs against the local Supabase instance, which the 'supabase-setup'
@@ -12,10 +11,6 @@ import { createClient } from '@supabase/supabase-js';
 
 const HAIR_TAG_ID = 'e2e00000-0000-0000-0000-000000000001';
 const MAKEUP_TAG_ID = 'e2e00000-0000-0000-0000-000000000003';
-const supabaseAdminClient = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SECRET_KEY!
-);
 
 test.describe('POST /api/inquiries (local Supabase)', () => {
   test('creates a real inquiry row end-to-end', async ({ request }) => {
@@ -38,31 +33,10 @@ test.describe('POST /api/inquiries (local Supabase)', () => {
       },
     });
 
-    if (response.status() !== 201) {
-      console.log('Status:', response.status());
-      console.log('Body:', await response.text());
-    }
-
     expect(response.status()).toBe(201);
     const body = await response.json();
     expect(body.ok).toBe(true);
     expect(typeof body.data.id).toBe('string');
-
-    const { data: inquiry, error } = await supabaseAdminClient
-      .from('inquiries')
-      .select('is_test_record, service_tag_ids, bride_first_name, bride_last_name, budget, people_count')
-      .eq('id', body.data.id)
-      .maybeSingle();
-
-    expect(error).toBeNull();
-    expect(inquiry).toMatchObject({
-      is_test_record: true,
-      service_tag_ids: [HAIR_TAG_ID, MAKEUP_TAG_ID],
-      bride_first_name: 'Playwright',
-      bride_last_name: 'Test',
-      budget: 500,
-      people_count: 4,
-    });
   });
 
   test('returns 500 for invalid inquiry, like an unknown vendor_id', async ({ request }) => {

--- a/frontend/e2e/inquiries/inquiries.public.spec.ts
+++ b/frontend/e2e/inquiries/inquiries.public.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Runs against the local Supabase instance, which the 'supabase-setup'
+ * Playwright project resets (migrations + seed.sql) once before the
+ * whole suite runs. That means:
+ *   - No per-test cleanup needed — every run starts from the same
+ *     known seeded state regardless of what earlier tests inserted.
+ *   - Vendor and tag ids below come straight from seed.sql.
+ */
+
+const HAIR_TAG_ID = 'e2e00000-0000-0000-0000-000000000001';
+const MAKEUP_TAG_ID = 'e2e00000-0000-0000-0000-000000000003';
+
+test.describe('POST /api/inquiries (local Supabase)', () => {
+  test('creates a real inquiry row end-to-end', async ({ request }) => {
+    const response = await request.post('/api/inquiries', {
+      data: {
+        vendor_id: 'TEST-E2E-002',
+        isTestRecord: true,
+        firstName: 'Playwright',
+        lastName: 'Test',
+        email: 'playwright-test@example.com',
+        additionalDetails: 'Automated Phase 0 e2e check.',
+        weddingDate: '2027-06-12',
+        flexibleDate: false,
+        location: 'Boston, MA',
+        budget: '500',
+        peopleCount: '4',
+        flexibleCount: false,
+        services: [HAIR_TAG_ID, MAKEUP_TAG_ID],
+        makeupStyles: ["Natural"],
+      },
+    });
+
+    if (response.status() !== 201) {
+      console.log('Status:', response.status());
+      console.log('Body:', await response.text());
+    }
+
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.data.id).toBe('string');
+  });
+
+  test('returns 500 for invalid inquiry, like an unknown vendor_id', async ({ request }) => {
+    const response = await request.post('/api/inquiries', {
+      data: {
+        vendor_id: 'definitely-not-a-real-vendor-id',
+        isTestRecord: true,
+        firstName: 'Playwright',
+        lastName: 'Test',
+        email: 'playwright-test@example.com',
+        additionalDetails: 'Automated Phase 0 e2e check.',
+        location: 'Boston, MA',
+        budget: '500',
+        peopleCount: '4',
+        services: [HAIR_TAG_ID],
+      },
+    });
+
+    expect(response.status()).toBe(500);
+    const body = await response.json();
+    expect(body).toEqual({
+      ok: false,
+      error: 'Could not save inquiry',
+      code: 'INSERT_FAILED',
+    });
+  });
+
+  test('returns 422 for an invalid payload', async ({ request }) => {
+    const response = await request.post('/api/inquiries', {
+      data: {
+        vendor_id: 'TEST-E2E-002',
+        isTestRecord: true,
+        firstName: '',
+        lastName: 'Test',
+        email: 'not-an-email',
+        additionalDetails: '',
+        location: '',
+        budget: '-1',
+        peopleCount: '0',
+        services: [],
+      },
+    });
+
+    expect(response.status()).toBe(422);
+    const body = await response.json();
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,7 +1,7 @@
 import nextConfig from "eslint-config-next/core-web-vitals";
 import nextTypescript from "eslint-config-next/typescript";
 
-const config =  [
+const config = [
   ...nextConfig,
   ...nextTypescript,
   {
@@ -9,6 +9,7 @@ const config =  [
       "@typescript-eslint/no-unused-vars": ["warn", {
         varsIgnorePattern: "^_",
         argsIgnorePattern: "^_",
+        ignoreRestSiblings: true
       }],
     },
   },

--- a/frontend/src/app/api/inquiries/route.ts
+++ b/frontend/src/app/api/inquiries/route.ts
@@ -32,6 +32,7 @@ export async function POST(
     .from("inquiries")
     .insert({
       vendor_id: input.vendor_id,
+      is_test_record: input.isTestRecord,
 
       bride_first_name: input.firstName,
       bride_last_name: input.lastName,
@@ -61,16 +62,13 @@ export async function POST(
   if (error) {
     console.error("Failed to insert inquiry", error);
 
-    // The DB trigger (inquiries_validate_service_tag_ids) raises with this
-    // message if a tag id doesn't exist or isn't a primary/service tag —
-    // surface that distinctly rather than as a generic 500, since it
-    // usually means stale client-side tag data, not a server problem.
-    if (error.message?.includes("valid primary/service tag")) {
-      return apiError(
-        "One or more selected services are no longer valid",
-        422,
-        "INVALID_SERVICE_TAGS"
-      );
+    const isForeignKeyViolation =
+      error.code === "23503" ||
+      error.message?.includes("foreign key") ||
+      error.message?.includes("violates foreign key constraint");
+
+    if (isForeignKeyViolation) {
+      return apiError("Vendor could not be found", 422, "INVALID_VENDOR");
     }
 
     return apiError("Could not save inquiry", 500, "INSERT_FAILED");

--- a/frontend/src/app/api/inquiries/route.ts
+++ b/frontend/src/app/api/inquiries/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ZodError } from "zod";
+import { supabaseAdminClient } from "@/lib/supabase/clients/adminClient";
+import { leadFormSchema } from "@/types/leadsValidation";
+import type { ApiResponse } from "@/types/api";
+import { apiError, apiSuccess } from "@/lib/api/respond";
+import { SubmitInquiryResponse } from "@/features/contact/api/submitInquiry";
+
+export async function POST(
+  req: NextRequest
+): Promise<NextResponse<ApiResponse<SubmitInquiryResponse>>> {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return apiError("Request body must be valid JSON", 400, "INVALID_JSON");
+  }
+
+  let input;
+  try {
+    input = leadFormSchema.parse(body);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const firstIssue = err.issues[0];
+      return apiError(firstIssue?.message ?? "Validation failed", 422, "VALIDATION_ERROR");
+    }
+    throw err;
+  }
+
+  const { data, error } = await supabaseAdminClient
+    .from("inquiries")
+    .insert({
+      vendor_id: input.vendor_id,
+
+      bride_first_name: input.firstName,
+      bride_last_name: input.lastName,
+      bride_email: input.email,
+      message: input.additionalDetails,
+
+      location: input.location,
+
+      wedding_date: input.weddingDate,
+      is_wedding_date_flexible: input.flexibleDate,
+
+      budget: input.budget,
+      is_budget_flexible: false, // no flexibleBudget field in current form
+
+      service_tag_ids: input.services,
+      makeup_styles: input.makeupStyles.length > 0 ? input.makeupStyles : null,
+
+      people_count: input.peopleCount,
+      is_people_count_flexible: input.flexibleCount,
+
+      // inquiry_status intentionally omitted -> table default 'pending_review'
+      submitted_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    console.error("Failed to insert inquiry", error);
+
+    // The DB trigger (inquiries_validate_service_tag_ids) raises with this
+    // message if a tag id doesn't exist or isn't a primary/service tag —
+    // surface that distinctly rather than as a generic 500, since it
+    // usually means stale client-side tag data, not a server problem.
+    if (error.message?.includes("valid primary/service tag")) {
+      return apiError(
+        "One or more selected services are no longer valid",
+        422,
+        "INVALID_SERVICE_TAGS"
+      );
+    }
+
+    return apiError("Could not save inquiry", 500, "INSERT_FAILED");
+  }
+
+  return apiSuccess({ id: data.id }, { status: 201 });
+}

--- a/frontend/src/features/contact/api/submitInquiry.ts
+++ b/frontend/src/features/contact/api/submitInquiry.ts
@@ -20,6 +20,7 @@ export async function submitInquiryToSupabase(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       vendor_id: vendor.id,
+      isTestRecord: formData.isTestRecord,
       services: formData.services,
       peopleCount: formData.peopleCount,
       flexibleCount: formData.flexibleCount,

--- a/frontend/src/features/contact/api/submitInquiry.ts
+++ b/frontend/src/features/contact/api/submitInquiry.ts
@@ -1,0 +1,44 @@
+import { LeadFormData } from '@/types/leads';
+import { VendorTag } from '@/types/vendor';
+import { fetchApi } from '@/lib/api/client';
+
+interface VendorInfo {
+  id: string;
+  serviceTags: VendorTag[];
+}
+
+export interface SubmitInquiryResponse {
+  id: string;
+}
+
+export async function submitInquiryToSupabase(
+  formData: LeadFormData,
+  vendor: VendorInfo
+): Promise<boolean> {
+  const response = await fetchApi<SubmitInquiryResponse>('/api/inquiries', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      vendor_id: vendor.id,
+      services: formData.services,
+      peopleCount: formData.peopleCount,
+      flexibleCount: formData.flexibleCount,
+      makeupStyles: formData.makeupStyles,
+      firstName: formData.firstName,
+      lastName: formData.lastName,
+      email: formData.email,
+      location: formData.location,
+      weddingDate: formData.weddingDate,
+      flexibleDate: formData.flexibleDate,
+      budget: formData.budget,
+      additionalDetails: formData.additionalDetails,
+    }),
+  });
+
+  if (!response.ok) {
+    console.error('Supabase inquiry submission failed:', response.code, response.error);
+    return false;
+  }
+
+  return true;
+}

--- a/frontend/src/features/contact/components/LeadCaptureForm.test.tsx
+++ b/frontend/src/features/contact/components/LeadCaptureForm.test.tsx
@@ -129,7 +129,7 @@ describe('LeadCaptureForm — service tag translation', () => {
 
     expect(screen.getByRole('button', { name: 'Hair' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Makeup' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Bridal Specialist' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Thai Makeup' })).not.toBeInTheDocument();
   });
 
   it('shows a configuration error and no selector when there are no primary service tags', () => {
@@ -173,7 +173,6 @@ describe('LeadCaptureForm — service tag translation', () => {
     // ...never the internal VendorTag ids.
     expect(submittedFormData.services).not.toEqual(expect.arrayContaining(['tag-abc', 'tag-xyz']));
 
-    await screen.findByText('Request Sent Successfully! 🎉');
   });
 
   it('also translates ids to display names in the step-1 partial lead save', async () => {
@@ -197,7 +196,7 @@ describe('LeadCaptureForm — service tag translation', () => {
     // Regression guard: if a service tag is deleted/renamed server-side after
     // the toggle group renders, getSelectedServiceLabels must silently drop
     // the stale id rather than sending `undefined` through to Airtable.
-    render(
+    const { rerender } = render(
       <LeadCaptureForm
         vendor={{ ...baseVendor, serviceTags: serviceTagsWithPrimaryOptions }}
         inquiryState={'not_verified' as unknown as InquiryState}
@@ -205,12 +204,24 @@ describe('LeadCaptureForm — service tag translation', () => {
     );
 
     await fillStep1AndContinue(['Hair']);
+
+    rerender(
+      <LeadCaptureForm
+        vendor={{
+          ...baseVendor,
+          serviceTags: serviceTagsWithPrimaryOptions.filter((tag) => tag.id !== 'tag-abc'),
+        }}
+        inquiryState={'not_verified' as unknown as InquiryState}
+      />
+    );
+
     await fillStep2();
     await userEvent.click(screen.getByRole('button', { name: /send inquiry|get my quote/i }));
 
     await waitFor(() => expect(mockedSubmitToAirtable).toHaveBeenCalledTimes(1));
     const [submittedFormData] = mockedSubmitToAirtable.mock.calls[0];
 
+    expect(submittedFormData.services).toEqual([]);
     expect(submittedFormData.services.every((label: string) => typeof label === 'string')).toBe(true);
     expect(submittedFormData.services).not.toContain(undefined);
   });

--- a/frontend/src/features/contact/components/LeadCaptureForm.test.tsx
+++ b/frontend/src/features/contact/components/LeadCaptureForm.test.tsx
@@ -6,34 +6,6 @@ import { savePartialLeadToAirtable, submitToAirtable } from '@/features/contact/
 import { VendorTag } from '@/types/vendor';
 import { InquiryState } from '@/features/profile/common/utils/getInquiryState';
 
-/**
- * ASSUMPTIONS — please correct me if these don't match your setup:
- *
- * 1. Vitest + @testing-library/react (+ @testing-library/user-event), with the
- *    '@/...' path alias resolved via vite-tsconfig-paths or an explicit
- *    `resolve.alias` in vitest.config — same alias the app itself uses.
- *    Test environment is assumed to be 'jsdom' (needed for DOM APIs below).
- * 2. `InquiryState` is a string union (e.g. 'verified' | 'not_verified' | 'opted_out').
- *    I couldn't see the exact type definition, so I cast the literal below —
- *    swap in the real values if they differ.
- * 3. Several fields in the component (peopleCount, budget) aren't wired up with
- *    accessible labels (no htmlFor/aria-label pointing at the visible
- *    <Typography> "label"), so a couple of queries below fall back to
- *    `document.body.querySelector('input[name="..."]')` / `input[type="number"]`
- *    instead of RTL's preferred `getByLabelText`. Adding `aria-label`s (or real
- *    <label htmlFor> elements) to those fields would let these tests (and
- *    screen readers) use proper accessible queries.
- *
- * FOCUS: these tests exercise the id -> display_name translation for service
- * tags. `formData.services` stores VendorTag ids (the source of truth used for
- * the toggle button `value`s), but Airtable submissions need the human-readable
- * `display_name`s. That conversion happens in a local, unexported
- * `getSelectedServiceLabels` closure, so it's only reachable indirectly by
- * driving the real UI and inspecting what gets handed to the mocked API calls.
- * If you pull that mapping out into an exported/pure helper, it'd be worth
- * adding a small direct unit test for it too (id not found -> dropped, empty
- * selection -> [], etc.) alongside these.
- */
 
 vi.mock('@/features/contact/api/airtable', () => ({
   savePartialLeadToAirtable: vi.fn().mockResolvedValue(true),
@@ -93,9 +65,9 @@ const baseVendor = {
 // should never show up as a selectable option, and deliberately non-sequential
 // ids so we can be sure we're asserting on translated *labels*, not ids.
 const serviceTagsWithPrimaryOptions: VendorTag[] = [
-  { id: 'tag-abc', display_name: 'Hair', style: 'primary' } as VendorTag,
-  { id: 'tag-xyz', display_name: 'Makeup', style: 'primary' } as VendorTag,
-  { id: 'tag-secondary', display_name: 'Bridal Specialist', style: 'secondary' } as VendorTag,
+  { id: 'tag-abc', display_name: 'Hair', type: 'SERVICE', is_visible: true, name: 'SPECIALTY_HAIR' } as VendorTag,
+  { id: 'tag-xyz', display_name: 'Makeup', type: 'SERVICE', is_visible: true, name: 'SPECIALTY_MAKEUP' } as VendorTag,
+  { id: 'tag-skill', display_name: 'Thai Makeup', type: 'SKILL', is_visible: true, name: 'SKILL_THAI' } as VendorTag,
 ];
 
 async function fillStep1AndContinue(services: string[] = ['Hair']) {

--- a/frontend/src/features/contact/components/LeadCaptureForm.test.tsx
+++ b/frontend/src/features/contact/components/LeadCaptureForm.test.tsx
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LeadCaptureForm from '@/features/contact/components/LeadCaptureForm';
+import { savePartialLeadToAirtable, submitToAirtable } from '@/features/contact/api/airtable';
+import { VendorTag } from '@/types/vendor';
+import { InquiryState } from '@/features/profile/common/utils/getInquiryState';
+
+/**
+ * ASSUMPTIONS — please correct me if these don't match your setup:
+ *
+ * 1. Vitest + @testing-library/react (+ @testing-library/user-event), with the
+ *    '@/...' path alias resolved via vite-tsconfig-paths or an explicit
+ *    `resolve.alias` in vitest.config — same alias the app itself uses.
+ *    Test environment is assumed to be 'jsdom' (needed for DOM APIs below).
+ * 2. `InquiryState` is a string union (e.g. 'verified' | 'not_verified' | 'opted_out').
+ *    I couldn't see the exact type definition, so I cast the literal below —
+ *    swap in the real values if they differ.
+ * 3. Several fields in the component (peopleCount, budget) aren't wired up with
+ *    accessible labels (no htmlFor/aria-label pointing at the visible
+ *    <Typography> "label"), so a couple of queries below fall back to
+ *    `document.body.querySelector('input[name="..."]')` / `input[type="number"]`
+ *    instead of RTL's preferred `getByLabelText`. Adding `aria-label`s (or real
+ *    <label htmlFor> elements) to those fields would let these tests (and
+ *    screen readers) use proper accessible queries.
+ *
+ * FOCUS: these tests exercise the id -> display_name translation for service
+ * tags. `formData.services` stores VendorTag ids (the source of truth used for
+ * the toggle button `value`s), but Airtable submissions need the human-readable
+ * `display_name`s. That conversion happens in a local, unexported
+ * `getSelectedServiceLabels` closure, so it's only reachable indirectly by
+ * driving the real UI and inspecting what gets handed to the mocked API calls.
+ * If you pull that mapping out into an exported/pure helper, it'd be worth
+ * adding a small direct unit test for it too (id not found -> dropped, empty
+ * selection -> [], etc.) alongside these.
+ */
+
+vi.mock('@/features/contact/api/airtable', () => ({
+  savePartialLeadToAirtable: vi.fn().mockResolvedValue(true),
+  submitToAirtable: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@/utils/analytics/trackFormEvents', () => ({
+  trackFormAbandonment: vi.fn(),
+  trackFormStarted: vi.fn(),
+  trackFormStepBack: vi.fn(),
+  trackFormSubmissionError: vi.fn(),
+  trackFormValidationErrors: vi.fn(),
+  trackPartialLeadSaved: vi.fn(),
+  trackStepProgress: vi.fn(),
+  trackVendorContactFormSubmission: vi.fn(),
+}));
+
+vi.mock('@/lib/env/env', () => ({
+  isDevOrPreview: vi.fn().mockReturnValue(false),
+}));
+
+const mockedSubmitToAirtable = vi.mocked(submitToAirtable);
+const mockedSavePartialLead = vi.mocked(savePartialLeadToAirtable);
+
+beforeAll(() => {
+  // jsdom doesn't implement matchMedia; MUI's useMediaQuery needs it.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedSubmitToAirtable.mockResolvedValue(true);
+  mockedSavePartialLead.mockResolvedValue(true);
+});
+
+const baseVendor = {
+  businessName: 'Glam by Jane',
+  slug: 'glam-by-jane',
+  id: 'vendor-1',
+  email: 'jane@example.com',
+  location: 'Los Angeles, CA',
+};
+
+// Two selectable ("primary") service tags, plus one "secondary" tag that
+// should never show up as a selectable option, and deliberately non-sequential
+// ids so we can be sure we're asserting on translated *labels*, not ids.
+const serviceTagsWithPrimaryOptions: VendorTag[] = [
+  { id: 'tag-abc', display_name: 'Hair', style: 'primary' } as VendorTag,
+  { id: 'tag-xyz', display_name: 'Makeup', style: 'primary' } as VendorTag,
+  { id: 'tag-secondary', display_name: 'Bridal Specialist', style: 'secondary' } as VendorTag,
+];
+
+async function fillStep1AndContinue(services: string[] = ['Hair']) {
+  for (const label of services) {
+    await userEvent.click(screen.getByRole('button', { name: label }));
+  }
+
+  await userEvent.type(
+    document.body.querySelector('input[name="location"]') as HTMLInputElement,
+    'Los Angeles, CA'
+  );
+  await userEvent.type(
+    document.body.querySelector('input[name="peopleCount"]') as HTMLInputElement,
+    '4'
+  );
+
+  await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+}
+
+async function fillStep2() {
+  await userEvent.type(
+    document.body.querySelector('input[name="firstName"]') as HTMLInputElement,
+    'Jane'
+  );
+  await userEvent.type(
+    document.body.querySelector('input[name="lastName"]') as HTMLInputElement,
+    'Doe'
+  );
+  await userEvent.type(
+    document.body.querySelector('input[name="email"]') as HTMLInputElement,
+    'jane.doe@example.com'
+  );
+  await userEvent.type(
+    document.body.querySelector('input[name="weddingDate"]') as HTMLInputElement,
+    '2027-06-15'
+  );
+  // Budget has no `name` attribute in the component — it's the only
+  // type="number" input rendered on step 2.
+  await userEvent.type(
+    document.body.querySelector('input[type="number"]') as HTMLInputElement,
+    '500'
+  );
+  await userEvent.type(
+    document.body.querySelector(
+      'textarea[name="additionalDetails"], input[name="additionalDetails"]'
+    ) as HTMLElement,
+    'Hi, I would love a natural bridal look.'
+  );
+}
+
+describe('LeadCaptureForm — service tag translation', () => {
+  it('only renders primary-style tags as selectable service options', () => {
+    render(
+      <LeadCaptureForm
+        vendor={{ ...baseVendor, serviceTags: serviceTagsWithPrimaryOptions }}
+        inquiryState={'not_verified' as unknown as InquiryState}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Hair' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Makeup' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Bridal Specialist' })).not.toBeInTheDocument();
+  });
+
+  it('shows a configuration error and no selector when there are no primary service tags', () => {
+    render(
+      <LeadCaptureForm
+        vendor={{
+          ...baseVendor,
+          serviceTags: [
+            { id: 'tag-secondary', display_name: 'Bridal Specialist', style: 'secondary' } as VendorTag,
+          ],
+        }}
+        inquiryState={'not_verified' as unknown as InquiryState}
+      />
+    );
+
+    expect(
+      screen.getByText(/this vendor doesn.?t have any services configured yet/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Bridal Specialist' })).not.toBeInTheDocument();
+  });
+
+  it('submits translated display names (not raw tag ids) to Airtable on final submit', async () => {
+    render(
+      <LeadCaptureForm
+        vendor={{ ...baseVendor, serviceTags: serviceTagsWithPrimaryOptions }}
+        inquiryState={'not_verified' as unknown as InquiryState}
+      />
+    );
+
+    await fillStep1AndContinue(['Hair', 'Makeup']);
+    await fillStep2();
+
+    await userEvent.click(screen.getByRole('button', { name: /send inquiry|get my quote/i }));
+
+    await waitFor(() => expect(mockedSubmitToAirtable).toHaveBeenCalledTimes(1));
+
+    const [submittedFormData] = mockedSubmitToAirtable.mock.calls[0];
+
+    // Must be the human-readable labels the Airtable base expects...
+    expect(new Set(submittedFormData.services)).toEqual(new Set(['Hair', 'Makeup']));
+    // ...never the internal VendorTag ids.
+    expect(submittedFormData.services).not.toEqual(expect.arrayContaining(['tag-abc', 'tag-xyz']));
+
+    await screen.findByText('Request Sent Successfully! 🎉');
+  });
+
+  it('also translates ids to display names in the step-1 partial lead save', async () => {
+    render(
+      <LeadCaptureForm
+        vendor={{ ...baseVendor, serviceTags: serviceTagsWithPrimaryOptions }}
+        inquiryState={'not_verified' as unknown as InquiryState}
+      />
+    );
+
+    await fillStep1AndContinue(['Makeup']);
+
+    await waitFor(() => expect(mockedSavePartialLead).toHaveBeenCalledTimes(1));
+
+    const [partialLead] = mockedSavePartialLead.mock.calls[0];
+    expect(partialLead.formData.services).toEqual(['Makeup']);
+    expect(partialLead.formData.services).not.toContain('tag-xyz');
+  });
+
+  it('drops a selected id that no longer matches any known service option', async () => {
+    // Regression guard: if a service tag is deleted/renamed server-side after
+    // the toggle group renders, getSelectedServiceLabels must silently drop
+    // the stale id rather than sending `undefined` through to Airtable.
+    render(
+      <LeadCaptureForm
+        vendor={{ ...baseVendor, serviceTags: serviceTagsWithPrimaryOptions }}
+        inquiryState={'not_verified' as unknown as InquiryState}
+      />
+    );
+
+    await fillStep1AndContinue(['Hair']);
+    await fillStep2();
+    await userEvent.click(screen.getByRole('button', { name: /send inquiry|get my quote/i }));
+
+    await waitFor(() => expect(mockedSubmitToAirtable).toHaveBeenCalledTimes(1));
+    const [submittedFormData] = mockedSubmitToAirtable.mock.calls[0];
+
+    expect(submittedFormData.services.every((label: string) => typeof label === 'string')).toBe(true);
+    expect(submittedFormData.services).not.toContain(undefined);
+  });
+});

--- a/frontend/src/features/contact/components/LeadCaptureForm.tsx
+++ b/frontend/src/features/contact/components/LeadCaptureForm.tsx
@@ -518,7 +518,6 @@ const LeadCaptureForm: React.FC<LeadCaptureFormProps> = ({
                 {hasNoServiceOptions ? (
                   <Alert severity="error">
                     This vendor doesn&apos;t have any services configured yet.
-                    Please check back later or contact support.
                   </Alert>
                 ) : (
                   <>

--- a/frontend/src/features/contact/components/LeadCaptureForm.tsx
+++ b/frontend/src/features/contact/components/LeadCaptureForm.tsx
@@ -31,6 +31,7 @@ import { VendorTag } from '@/types/vendor';
 import { InquiryState } from '@/features/profile/common/utils/getInquiryState';
 import { isDevOrPreview } from '@/lib/env/env';
 import { LeadFormData, LeadFormErrors, LeadStatus, PartialLead } from '@/types/leads';
+import { getSelectedServiceLabels } from '@/lib/directory/getServiceTagNames';
 
 interface LeadCaptureFormProps {
   onClose?: () => void;
@@ -157,11 +158,16 @@ const LeadCaptureForm: React.FC<LeadCaptureFormProps> = ({
   // 2-step process
   const steps = ['Artist fit', 'Personal details'];
 
-  const serviceOptions: string[] = vendor.serviceTags && vendor.serviceTags.length > 0
-    ? vendor.serviceTags.map(
-      (serviceTag: VendorTag) => serviceTag.display_name)
-      .filter((name): name is string => typeof name === 'string')
-    : ["Hair", "Makeup"];
+  // tag ids and display names of the services offered (makeup or hair)
+  const serviceOptions: VendorTag[] = vendor.serviceTags
+    .filter((t: VendorTag) => t.id && t.display_name && t.type === 'SERVICE');
+
+  const selectedServiceLabels = useMemo(
+    () => getSelectedServiceLabels(formData.services, serviceOptions),
+    [formData.services, serviceOptions]
+  );
+
+  const hasNoServiceOptions = serviceOptions.length === 0;
 
   const makeupStyleOptions = [
     'Natural',
@@ -186,6 +192,9 @@ const LeadCaptureForm: React.FC<LeadCaptureFormProps> = ({
     return completed;
   }, [formData]);
 
+  const getTimeSpentSeconds = (startTime: number): number =>
+    Math.round((Date.now() - startTime) / 1000);
+
   useEffect(() => {
     const startTime = formStartTime;
     trackFormStarted({
@@ -196,7 +205,7 @@ const LeadCaptureForm: React.FC<LeadCaptureFormProps> = ({
     return () => {
       // Track abandonment on component unmount if not submitted
       if (!submitted) {
-        const timeSpent = Math.round((Date.now() - startTime) / 1000);
+        const timeSpent = getTimeSpentSeconds(startTime);
         trackFormAbandonment({
           step_number: activeStep + 1,
           fields_completed: completedFields,
@@ -297,12 +306,15 @@ const LeadCaptureForm: React.FC<LeadCaptureFormProps> = ({
   const handleNext = async () => {
 
     if (validateCurrentStep()) {
-      const timeSpent = Math.round((Date.now() - formStartTime) / 1000);
+      const timeSpent = getTimeSpentSeconds(formStartTime);
 
       // Save partial lead when completing Step 1
       if (activeStep === 0) {
         const partialLead: PartialLead = {
-          formData,
+          formData: {
+            ...formData,
+            services: selectedServiceLabels,
+          },
           vendor: {
             businessName: vendor.businessName,
             slug: vendor.slug,
@@ -341,14 +353,16 @@ const LeadCaptureForm: React.FC<LeadCaptureFormProps> = ({
     });
     setActiveStep(prev => prev - 1);
   };
-
   const handleClose = async () => {
-    const timeSpent = Math.round((Date.now() - formStartTime) / 1000);
+    const timeSpent = getTimeSpentSeconds(formStartTime);
 
     // Save partial lead if they have email or completed step 1
     if ((activeStep === 1 && formData.email) || (activeStep >= 0 && completedFields.length >= 3)) {
       const partialLead: PartialLead = {
-        formData,
+        formData: {
+          ...formData,
+          services: selectedServiceLabels,
+        },
         vendor: {
           businessName: vendor.businessName,
           slug: vendor.slug,
@@ -393,17 +407,21 @@ const LeadCaptureForm: React.FC<LeadCaptureFormProps> = ({
     setIsSubmitting(true);
 
     try {
-      const success = await submitToAirtable(formData, vendor);
+      const airtableFormData: LeadFormData = {
+        ...formData,
+        services: selectedServiceLabels,
+      };
+      const success = await submitToAirtable(airtableFormData, vendor);
 
       if (success) {
         setSubmitted(true);
-        const timeSpent = Math.round((Date.now() - formStartTime) / 1000);
+        const timeSpent = getTimeSpentSeconds(formStartTime);
 
         // Track successful conversion
         trackVendorContactFormSubmission({
           form_type: 'vendor_contact',
           vendor_slug: vendor.slug,
-          services: formData.services.join(', '),
+          services: airtableFormData.services.join(', '),
           location: formData.location,
           people_count: formData.peopleCount,
           budget: formData.budget,
@@ -497,29 +515,36 @@ const LeadCaptureForm: React.FC<LeadCaptureFormProps> = ({
                 <Typography variant="h5" gutterBottom sx={{ fontWeight: 500 }}>
                   Which services do you need? *
                 </Typography>
-                <StyledToggleButtonGroup
-                  value={formData.services}
-                  onChange={(e, newValue) => {
-                    // Allow newValue to be empty array or have values
-                    setFormData({ ...formData, services: newValue || [] });
-                    // Clear error when user makes a selection
-                    if (errors.services) {
-                      setErrors(prev => ({ ...prev, services: null }));
-                    }
-                  }}
-                  color="primary"
-                  aria-label="services"
-                >
-                  {serviceOptions.map(service => (
-                    <ToggleButton key={service} value={service}>
-                      {service}
-                    </ToggleButton>
-                  ))}
-                </StyledToggleButtonGroup>
-                {errors.services && (
-                  <Typography variant="caption" color="error" sx={{ ml: 0, mt: 0.5, display: 'block' }}>
-                    {errors.services}
-                  </Typography>
+                {hasNoServiceOptions ? (
+                  <Alert severity="error">
+                    This vendor doesn&apos;t have any services configured yet.
+                    Please check back later or contact support.
+                  </Alert>
+                ) : (
+                  <>
+                    <StyledToggleButtonGroup
+                      value={formData.services}
+                      onChange={(e, newValue) => {
+                        setFormData({ ...formData, services: newValue || [] });
+                        if (errors.services) {
+                          setErrors(prev => ({ ...prev, services: null }));
+                        }
+                      }}
+                      color="primary"
+                      aria-label="services"
+                    >
+                      {serviceOptions.map(({ id, display_name }) => (
+                        <ToggleButton key={id} value={id}>
+                          {display_name}
+                        </ToggleButton>
+                      ))}
+                    </StyledToggleButtonGroup>
+                    {errors.services && (
+                      <Typography variant="caption" color="error" sx={{ ml: 0, mt: 0.5, display: 'block' }}>
+                        {errors.services}
+                      </Typography>
+                    )}
+                  </>
                 )}
               </Grid>
 

--- a/frontend/src/lib/directory/getServiceTagNames.test.ts
+++ b/frontend/src/lib/directory/getServiceTagNames.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { VendorTag } from '@/types/vendor';
+import { getSelectedServiceLabels } from './getServiceTagNames';
+
+const HAIR_TAG_ID = 'e2e00000-0000-0000-0000-000000000001';
+const MAKEUP_TAG_ID = 'e2e00000-0000-0000-0000-000000000003';
+
+const serviceOptions: VendorTag[] = [
+  { id: HAIR_TAG_ID, name: "SPECIALTY_HAIR", display_name: 'Hair', style: 'primary', type: 'SERVICE', is_visible: true },
+  { id: MAKEUP_TAG_ID, name: "SPECIALTY_MAKEUP", display_name: 'Makeup', style: 'primary', type: 'SERVICE', is_visible: true },
+];
+
+describe('getSelectedServiceLabels', () => {
+  it('translates selected ids to their display names', () => {
+    expect(getSelectedServiceLabels([HAIR_TAG_ID, MAKEUP_TAG_ID], serviceOptions)).toEqual([
+      'Hair',
+      'Makeup',
+    ]);
+  });
+
+  it('preserves the order of selectedIds, not serviceOptions', () => {
+    expect(getSelectedServiceLabels([MAKEUP_TAG_ID, HAIR_TAG_ID], serviceOptions)).toEqual([
+      'Makeup',
+      'Hair',
+    ]);
+  });
+
+  it('returns an empty array when nothing is selected', () => {
+    expect(getSelectedServiceLabels([], serviceOptions)).toEqual([]);
+  });
+
+  it('drops ids that have no matching service option', () => {
+    expect(getSelectedServiceLabels([HAIR_TAG_ID, 'tag-stale'], serviceOptions)).toEqual(['Hair']);
+  });
+
+  it('returns an empty array when none of the selected ids match', () => {
+    expect(getSelectedServiceLabels(['tag-stale-1', 'tag-stale-2'], serviceOptions)).toEqual([]);
+  });
+
+  it('returns an empty array when there are no service options at all', () => {
+    expect(getSelectedServiceLabels([HAIR_TAG_ID], [])).toEqual([]);
+  });
+});

--- a/frontend/src/lib/directory/getServiceTagNames.ts
+++ b/frontend/src/lib/directory/getServiceTagNames.ts
@@ -1,0 +1,10 @@
+import { VendorTag } from "@/types/vendor";
+
+export function getSelectedServiceLabels(
+  selectedIds: string[],
+  serviceOptions: VendorTag[]
+): string[] {
+  return selectedIds
+    .map((id) => serviceOptions.find((opt) => opt.id === id)?.display_name)
+    .filter((label): label is string => Boolean(label));
+}

--- a/frontend/src/types/leads.test.ts
+++ b/frontend/src/types/leads.test.ts
@@ -77,6 +77,11 @@ describe('leadFormSchema', () => {
     expect(() => leadFormSchema.parse(payload)).toThrow();
   });
 
+  it.each(['', '   '])('rejects a blank budget value %p', (value) => {
+    const payload = { ...validPayload, budget: value };
+    expect(() => leadFormSchema.parse(payload)).toThrow();
+  });
+
   it('rejects a non-numeric budget', () => {
     const payload = { ...validPayload, budget: 'lots' };
     expect(() => leadFormSchema.parse(payload)).toThrow();

--- a/frontend/src/types/leads.test.ts
+++ b/frontend/src/types/leads.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { leadFormSchema } from './leadsValidation';
+
+const HAIR_TAG_ID = 'e2e00000-0000-0000-0000-000000000001';
+const MAKEUP_TAG_ID = 'e2e00000-0000-0000-0000-000000000002';
+
+const validPayload = {
+  vendor_id: 'vendor-123',
+  isTestRecord: true,
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane@example.com',
+  additionalDetails: 'Looking for a natural bridal look.',
+  weddingDate: '2027-06-12',
+  flexibleDate: false,
+  location: 'Boston, MA',
+  budget: '500',
+  peopleCount: '4',
+  flexibleCount: false,
+  services: [HAIR_TAG_ID, MAKEUP_TAG_ID],
+  makeupStyles: ['Natural'],
+};
+
+describe('leadFormSchema', () => {
+  it('accepts a fully valid payload', () => {
+    const result = leadFormSchema.parse(validPayload);
+    expect(result.vendor_id).toBe('vendor-123');
+    expect(result.services).toEqual([HAIR_TAG_ID, MAKEUP_TAG_ID]);
+  });
+
+  it('coerces budget and peopleCount from string to number', () => {
+    const result = leadFormSchema.parse(validPayload);
+    expect(result.budget).toBe(500);
+    expect(typeof result.budget).toBe('number');
+    expect(result.peopleCount).toBe(4);
+    expect(typeof result.peopleCount).toBe('number');
+  });
+
+  it('defaults isTestRecord, flexibleDate, flexibleCount, makeupStyles', () => {
+    const { isTestRecord, flexibleDate, flexibleCount, makeupStyles, ...rest } =
+      validPayload;
+    const result = leadFormSchema.parse(rest);
+    expect(result.isTestRecord).toBe(false);
+    expect(result.flexibleDate).toBe(false);
+    expect(result.flexibleCount).toBe(false);
+    expect(result.makeupStyles).toEqual([]);
+  });
+
+  it.each([
+    ['vendor_id', ''],
+    ['firstName', ''],
+    ['lastName', ''],
+    ['location', ''],
+    ['additionalDetails', ''],
+  ])('rejects empty required field %s', (field, value) => {
+    const payload = { ...validPayload, [field]: value };
+    expect(() => leadFormSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects an invalid email', () => {
+    const payload = { ...validPayload, email: 'not-an-email' };
+    expect(() => leadFormSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects a malformed weddingDate', () => {
+    const payload = { ...validPayload, weddingDate: '06/12/2027' };
+    expect(() => leadFormSchema.parse(payload)).toThrow();
+  });
+
+  it('allows weddingDate to be omitted', () => {
+    const { weddingDate, ...rest } = validPayload;
+    expect(() => leadFormSchema.parse(rest)).not.toThrow();
+  });
+
+  it('rejects a negative budget', () => {
+    const payload = { ...validPayload, budget: '-1' };
+    expect(() => leadFormSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects a non-numeric budget', () => {
+    const payload = { ...validPayload, budget: 'lots' };
+    expect(() => leadFormSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects peopleCount of zero or negative', () => {
+    expect(() =>
+      leadFormSchema.parse({ ...validPayload, peopleCount: '0' })
+    ).toThrow();
+    expect(() =>
+      leadFormSchema.parse({ ...validPayload, peopleCount: '-2' })
+    ).toThrow();
+  });
+
+  it('rejects an empty services array', () => {
+    const payload = { ...validPayload, services: [] };
+    expect(() => leadFormSchema.parse(payload)).toThrow();
+  });
+});

--- a/frontend/src/types/leadsValidation.ts
+++ b/frontend/src/types/leadsValidation.ts
@@ -19,21 +19,26 @@ export const leadFormSchema = z.object({
   email: z.string().trim().email('Enter a valid email address').max(255),
   additionalDetails: z.string().trim().min(1, 'Message is required').max(5000),
 
-  weddingDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, 'weddingDate must be YYYY-MM-DD')
-    .optional(),
+  weddingDate: z.iso.date().optional(),
   flexibleDate: z.boolean().default(false),
 
   location: z.string().trim().min(1, 'Location is required').max(255),
 
   // Sent as a string from the form's number input; coerce + validate here.
-  budget: z.coerce
-    .number({
-      error: () => "Enter a valid budget"
-    })
-    .nonnegative()
-    .max(1_000_000),
+  budget: z.preprocess(
+    (value) => {
+      if (typeof value === 'string' && value.trim() === '') {
+        return undefined;
+      }
+      return value;
+    },
+    z.coerce
+      .number({
+        error: () => "Enter a valid budget"
+      })
+      .nonnegative()
+      .max(1_000_000)
+  ),
 
   peopleCount: z.coerce
     .number({
@@ -41,7 +46,7 @@ export const leadFormSchema = z.object({
     })
     .int()
     .positive()
-    .max(1000),
+    .max(100),
   flexibleCount: z.boolean().default(false),
 
   // Expected to be an array of tag ids, not tag names
@@ -49,7 +54,7 @@ export const leadFormSchema = z.object({
     .array(z.guid('Each service must be a valid tag id'))
     .min(1, 'At least one service is required'),
 
-  makeupStyles: z.array(z.string().trim().max(100)).default([]),
+  makeupStyles: z.array(z.string().trim().max(10)).default([]),
 });
 
 export type LeadFormWireInput = z.infer<typeof leadFormSchema>;

--- a/frontend/src/types/leadsValidation.ts
+++ b/frontend/src/types/leadsValidation.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+// leadFormSchema below describes what the api accepts over the wire
+//
+// Field names here are camelCase, matching LeadFormData, NOT the DB's
+// snake_case inquiries columns — the API route does that translation.
+//
+// Deliberately NOT accepted here (server-controlled or set later):
+//   id, inquiry_status, outcome_status, submitted_at, airtable_record_id,
+//   contacted_at, expires_at, unlocked_at, declined_at, booked_trial_at,
+//   booked_wedding_at, stripe_payment_id, unlock_method, unlock_price,
+//   created_at, updated_at, is_budget_flexible (no UI control for this yet)
+export const leadFormSchema = z.object({
+  vendor_id: z.string().min(1, 'vendor_id is required'),
+  isTestRecord: z.boolean().default(false),
+
+  firstName: z.string().trim().min(1, 'First name is required').max(100),
+  lastName: z.string().trim().min(1, 'Last name is required').max(100),
+  email: z.string().trim().email('Enter a valid email address').max(255),
+  additionalDetails: z.string().trim().min(1, 'Message is required').max(5000),
+
+  weddingDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'weddingDate must be YYYY-MM-DD')
+    .optional(),
+  flexibleDate: z.boolean().default(false),
+
+  location: z.string().trim().min(1, 'Location is required').max(255),
+
+  // Sent as a string from the form's number input; coerce + validate here.
+  budget: z.coerce
+    .number({
+      error: () => "Enter a valid budget"
+    })
+    .nonnegative()
+    .max(1_000_000),
+
+  peopleCount: z.coerce
+    .number({
+      error: () => "Enter a valid number of people"
+    })
+    .int()
+    .positive()
+    .max(1000),
+  flexibleCount: z.boolean().default(false),
+
+  // Expected to be an array of tag ids, not tag names
+  services: z
+    .array(z.guid('Each service must be a valid tag id'))
+    .min(1, 'At least one service is required'),
+
+  makeupStyles: z.array(z.string().trim().max(100)).default([]),
+});
+
+export type LeadFormWireInput = z.infer<typeof leadFormSchema>;

--- a/frontend/supabase/migrations/20260703155935_create_inquiries_table.sql
+++ b/frontend/supabase/migrations/20260703155935_create_inquiries_table.sql
@@ -1,0 +1,83 @@
+-- Create inquiries table (migrated from Airtable "Leads")
+
+create type inquiry_status as enum (
+  'pending_review',
+  'new',
+  'unlocked',
+  'declined',
+  'expired'
+);
+
+create type outcome_status as enum (
+  'contacted',
+  'booked_trial',
+  'booked_wedding',
+  'no_response',
+  'lost'
+);
+
+create type service_type as enum (
+  'hair',
+  'makeup'
+);
+
+create table if not exists inquiries (
+  id uuid primary key default gen_random_uuid(),
+  vendor_id text not null references vendors(id),
+  airtable_record_id text unique,
+
+  inquiry_status inquiry_status not null default 'pending_review',
+  outcome_status outcome_status,
+
+  submitted_at timestamptz not null,
+  wedding_date date,
+  is_wedding_date_flexible boolean not null default false,
+  location text,
+  budget numeric(10,2),
+  is_budget_flexible boolean not null default false,
+  services service_type[] not null default '{}',
+  people_count int,
+  is_people_count_flexible boolean not null default false,
+  bride_first_name text,
+
+  -- Post-unlock fields
+  makeup_styles text[],
+  bride_last_name text,
+  bride_email text,
+  message text,
+
+  contacted_at timestamptz,
+  expires_at timestamptz,
+  unlocked_at timestamptz,
+  declined_at timestamptz,
+  booked_trial_at timestamptz,
+  booked_wedding_at timestamptz,
+
+  stripe_payment_id text,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  -- outcome_status can only be set once the inquiry has been unlocked
+  constraint outcome_requires_unlocked check (
+    outcome_status is null or inquiry_status = 'unlocked'
+  )
+);
+
+create index if not exists idx_inquiries_vendor_id on inquiries (vendor_id);
+create index if not exists idx_inquiries_inquiry_status on inquiries (inquiry_status);
+create index if not exists idx_inquiries_submitted_at on inquiries (submitted_at);
+
+-- keep updated_at current on every row change
+create or replace function set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger inquiries_set_updated_at
+before update on inquiries
+for each row
+execute function set_updated_at();

--- a/frontend/supabase/migrations/20260703181553_update_inquiries_table.sql
+++ b/frontend/supabase/migrations/20260703181553_update_inquiries_table.sql
@@ -1,0 +1,38 @@
+-- Create new enum
+create type unlock_method as enum (
+  'paid',
+  'admin_grant'
+);
+
+-- Rename enum values
+alter type inquiry_status rename value 'new' to 'available';
+
+alter type inquiry_status add value 'stalled';
+alter type inquiry_status add value 'booked_trial_or_wedding'; --for legacy airtable
+
+-- Add new columns
+alter table inquiries
+add column unlock_method unlock_method,
+add column unlock_price numeric(10,2),
+add column is_test_record boolean not null default false;
+
+-- Update constraint
+alter table inquiries
+drop constraint outcome_requires_unlocked;
+
+alter table inquiries
+add constraint unlocked_requires_method check (
+  inquiry_status <> 'unlocked'
+  or unlock_method is not null
+);
+
+alter table inquiries enable row level security;
+
+alter table inquiries
+add column service_tag_ids uuid[] not null default '{}';
+
+alter table inquiries drop column services;
+drop type if exists service_type;
+
+create index if not exists idx_inquiries_service_tag_ids
+  on inquiries using gin (service_tag_ids);

--- a/frontend/supabase/seed.sql
+++ b/frontend/supabase/seed.sql
@@ -209,11 +209,11 @@ VALUES
   ('TEST-E2E-CLAIM', 'Test Claim Vendor', 'test-claim-vendor', false, 'Seattle', 'Washington', 'United States', 'claim-vendor@example.com', '11111111-1111-1111-1111-111111111111', null, null);
 
 -- Test tags  (style='primary' → Service chip; anything else → Skill chip)
-INSERT INTO public.tags (id, name, display_name, is_visible, style)
+INSERT INTO public.tags (id, name, display_name, is_visible, style, type)
 VALUES
-  ('e2e00000-0000-0000-0000-000000000001', 'SPECIALTY_HAIR', 'Hair',       true, 'primary'),
-  ('e2e00000-0000-0000-0000-000000000002', 'SKILL_THAI',     'Thai Makeup', true, 'default'),
-  ('e2e00000-0000-0000-0000-000000000003', 'SPECIALTY_MAKEUP', 'Makeup', true, 'primary');
+  ('e2e00000-0000-0000-0000-000000000001', 'SPECIALTY_HAIR', 'Hair',       true, 'primary', 'SERVICE'),
+  ('e2e00000-0000-0000-0000-000000000002', 'SKILL_THAI',     'Thai Makeup', true, 'default', 'SKILL'),
+  ('e2e00000-0000-0000-0000-000000000003', 'SPECIALTY_MAKEUP', 'Makeup', true, 'primary', 'SERVICE');
 
 
 -- Link vendors → tags


### PR DESCRIPTION
Set up for inquiry lifecycle on Supabase, instead of Airtable. I've added a new inquiries table and api route for submitting an inquiry on supabase. The application logic has **not** been rewired to use the new api yet, so the inquiry process is still using Airtable

- **Changes**
  - sql migrations for a new supabase inquiries table
  - /api/inquiries route for creating a new inquiry in supabase
  - zod validation for the new inquiry api route
  - use tag ids instead of display names in the LeadCaptureForm. For backwards-compatibility, continue to use display names for Airtable

- **Tests**
  - Added e2e test for the new api test
  - Added unit tests to make sure LeadCaptureForm doesn't break with the tag change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced end-to-end inquiry submission with server-side validation and clear error responses for invalid payloads and unknown vendors.
  * Lead capture service choices now reflect each vendor’s configured service tags.
* **Bug Fixes**
  * Prevented stale or removed service selections from being submitted; shows an error state when a vendor has no configured services.
* **Tests**
  * Added unit tests for service-label mapping and lead form validation, plus Playwright E2E coverage for inquiry creation.
* **Chores**
  * Updated ESLint configuration for unused variables handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->