### PR TITLE
redirect filter searches to new directory route

### DIFF
--- a/frontend/e2e/redirect/directory-redirect.public.spec.ts
+++ b/frontend/e2e/redirect/directory-redirect.public.spec.ts
@@ -19,3 +19,36 @@ test('directory page itself is not redirected', async ({ page }) => {
   await page.goto('/vendors?lat=40.7127&lon=-74.006');
   expect(page.url()).toContain('/vendors?lat=40.7127&lon=-74.006');
 });
+
+test('filters can be cleared after landing via the directory redirect', async ({ page }) => {
+  // Arrive via the redirect path (simulating an old Reddit link)
+  await page.goto('/?lat=40.7127&lon=-74.006&skill=Thai+Makeup');
+  await expect(page).toHaveURL(/\/vendors\?.*skill=Thai\+Makeup/);
+
+
+  // Confirm the skill filter chip is rendered
+  const activeFilters = page.getByTestId('active-filters');
+  const skillChip = activeFilters.locator('.MuiChip-root', { hasText: 'Thai Makeup' });
+  await expect(skillChip).toBeVisible();
+
+  // Clear it via the chip's delete icon
+  await skillChip.getByTestId('CancelIcon').click();
+
+  // URL param should be gone
+  await expect(page).not.toHaveURL(/skill=Thai\+Makeup/);
+
+  // Chip should disappear
+  await expect(skillChip).not.toBeVisible();
+});
+
+test('filters can be cleared on a direct /vendors visit (no redirect)', async ({ page }) => {
+  await page.goto('/vendors?skill=Thai+Makeup');
+
+  const activeFilters = page.getByTestId('active-filters');
+  const skillChip = activeFilters.locator('.MuiChip-root', { hasText: 'Thai Makeup' });
+
+  await skillChip.getByTestId('CancelIcon').click();
+
+  await expect(page).not.toHaveURL(/skill=Thai\+Makeup/);
+  await expect(skillChip).not.toBeVisible();
+});

--- a/frontend/e2e/redirect/directory-redirect.public.spec.ts
+++ b/frontend/e2e/redirect/directory-redirect.public.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('old Reddit-style homepage link redirects to filtered directory', async ({ page }) => {
+  const response = await page.goto('/?lat=40.7127&lon=-74.006');
+
+  expect(response?.status()).toBe(200); // final response after following redirect
+  expect(page.url()).toContain('/vendors?lat=40.7127&lon=-74.006');
+
+  // Confirm the directory page actually applied the filter, not just that the URL looks right
+  await expect(page.getByText("Wedding Beauty Artists found near New York City")).toBeVisible(); // adjust to a real filtered-result assertion
+});
+
+test('homepage without filter params does not redirect', async ({ page }) => {
+  await page.goto('/');
+  expect(page.url()).not.toContain('/vendors');
+});
+
+test('directory page itself is not redirected', async ({ page }) => {
+  await page.goto('/vendors?lat=40.7127&lon=-74.006');
+  expect(page.url()).toContain('/vendors?lat=40.7127&lon=-74.006');
+});

--- a/frontend/e2e/redirect/directory-redirect.public.spec.ts
+++ b/frontend/e2e/redirect/directory-redirect.public.spec.ts
@@ -7,7 +7,7 @@ test('old Reddit-style homepage link redirects to filtered directory', async ({ 
   expect(page.url()).toContain('/vendors?lat=40.7127&lon=-74.006');
 
   // Confirm the directory page actually applied the filter, not just that the URL looks right
-  await expect(page.getByText("Wedding Beauty Artists found near New York City")).toBeVisible(); // adjust to a real filtered-result assertion
+  await expect(page.getByText("Wedding Beauty Artists found near New York City")).toBeVisible();
 });
 
 test('homepage without filter params does not redirect', async ({ page }) => {

--- a/frontend/e2e/redirect/directory-redirect.public.spec.ts
+++ b/frontend/e2e/redirect/directory-redirect.public.spec.ts
@@ -23,8 +23,9 @@ test('directory page itself is not redirected', async ({ page }) => {
 test('filters can be cleared after landing via the directory redirect', async ({ page }) => {
   // Arrive via the redirect path (simulating an old Reddit link)
   await page.goto('/?lat=40.7127&lon=-74.006&skill=Thai+Makeup');
-  await expect(page).toHaveURL(/\/vendors\?.*skill=Thai\+Makeup/);
 
+  let params = new URL(page.url()).searchParams;
+  expect(params.get('skill')).toBe('Thai Makeup');
 
   // Confirm the skill filter chip is rendered
   const activeFilters = page.getByTestId('active-filters');
@@ -35,20 +36,23 @@ test('filters can be cleared after landing via the directory redirect', async ({
   await skillChip.getByTestId('CancelIcon').click();
 
   // URL param should be gone
-  await expect(page).not.toHaveURL(/skill=Thai\+Makeup/);
-
-  // Chip should disappear
   await expect(skillChip).not.toBeVisible();
+  params = new URL(page.url()).searchParams;
+  expect(params.has('skill')).toBe(false);
 });
 
 test('filters can be cleared on a direct /vendors visit (no redirect)', async ({ page }) => {
   await page.goto('/vendors?skill=Thai+Makeup');
+
+  let params = new URL(page.url()).searchParams;
+  expect(params.get('skill')).toBe('Thai Makeup');
 
   const activeFilters = page.getByTestId('active-filters');
   const skillChip = activeFilters.locator('.MuiChip-root', { hasText: 'Thai Makeup' });
 
   await skillChip.getByTestId('CancelIcon').click();
 
-  await expect(page).not.toHaveURL(/skill=Thai\+Makeup/);
   await expect(skillChip).not.toBeVisible();
+  params = new URL(page.url()).searchParams;
+  expect(params.has('skill')).toBe(false);
 });

--- a/frontend/src/features/directory/components/filters/LocationAutocomplete.tsx
+++ b/frontend/src/features/directory/components/filters/LocationAutocomplete.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
 import {

--- a/frontend/src/features/directory/components/tableLayout/ResultsHeader.tsx
+++ b/frontend/src/features/directory/components/tableLayout/ResultsHeader.tsx
@@ -68,6 +68,7 @@ export const ResultsHeader = ({
       {/* Filter Pills Row */}
       {hasFilters && (
         <Box
+          data-testid="active-filters"
           sx={{
             display: 'flex',
             flexWrap: 'wrap',

--- a/frontend/src/hooks/useURLFilters.test.ts
+++ b/frontend/src/hooks/useURLFilters.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useURLFilters } from './useURLFilters';
+import {
+  TRAVEL_PARAM,
+  SKILL_PARAM,
+  SERVICE_PARAM,
+  LATITUDE_PARAM,
+  LONGITUDE_PARAM,
+} from '@/lib/constants';
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+function setLocation(url: string) {
+  const parsed = new URL(url);
+  // @ts-expect-error - intentional override for test control
+  delete window.location;
+  window.location = parsed as unknown as string & Location;
+}
+
+describe('useURLFilters', () => {
+  const replaceMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
+      replace: replaceMock,
+      push: vi.fn(),
+    });
+  });
+
+  function mockSearchParamsFrom(search: string) {
+    const params = new URLSearchParams(search);
+    (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(params);
+    return params;
+  }
+
+  describe('getParam / getAllParams', () => {
+    it('reads a single service param value', () => {
+      mockSearchParamsFrom(`${SERVICE_PARAM}=Makeup`);
+      setLocation(`https://example.com/vendors?${SERVICE_PARAM}=Makeup`);
+
+      const { result } = renderHook(() => useURLFilters());
+      expect(result.current.getParam(SERVICE_PARAM)).toBe('Makeup');
+    });
+
+    it('returns null for a missing param', () => {
+      mockSearchParamsFrom('');
+      setLocation('https://example.com/vendors');
+
+      const { result } = renderHook(() => useURLFilters());
+      expect(result.current.getParam(SKILL_PARAM)).toBeNull();
+    });
+
+    it('reads all values for a repeated skill param', () => {
+      mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+
+      const { result } = renderHook(() => useURLFilters());
+      expect(result.current.getAllParams(SKILL_PARAM)).toEqual(['Thai Makeup', 'South Asian Makeup']);
+    });
+  });
+
+  describe('paramsString', () => {
+    it('mirrors the current searchParams as a string', () => {
+      mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127`);
+      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127`);
+
+      const { result } = renderHook(() => useURLFilters());
+      expect(result.current.paramsString).toBe(`${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127`);
+    });
+
+    it('is an empty string when there are no params', () => {
+      mockSearchParamsFrom('');
+      setLocation('https://example.com/vendors');
+
+      const { result } = renderHook(() => useURLFilters());
+      expect(result.current.paramsString).toBe('');
+    });
+  });
+
+  describe('setParams', () => {
+    it('adds a new skill filter while preserving an existing location filter', () => {
+      mockSearchParamsFrom(`${LATITUDE_PARAM}=40.7127&${LONGITUDE_PARAM}=-74.006`);
+      setLocation(`https://example.com/vendors?${LATITUDE_PARAM}=40.7127&${LONGITUDE_PARAM}=-74.006`);
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setParams({ [SKILL_PARAM]: 'Thai Makeup' });
+      });
+
+      expect(replaceMock).toHaveBeenCalledOnce();
+      const [calledUrl, options] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      expect(url.pathname).toBe('/vendors');
+      expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
+      expect(url.searchParams.get(LONGITUDE_PARAM)).toBe('-74.006');
+      expect(url.searchParams.get(SKILL_PARAM)).toBe('Thai Makeup');
+      expect(options).toEqual({ scroll: false });
+    });
+
+    it('removes a service param when value is null', () => {
+      mockSearchParamsFrom(`${SERVICE_PARAM}=Hair&${LATITUDE_PARAM}=40.7127`);
+      setLocation(`https://example.com/vendors?${SERVICE_PARAM}=Hair&${LATITUDE_PARAM}=40.7127`);
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setParams({ [SERVICE_PARAM]: null });
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      expect(url.searchParams.has(SERVICE_PARAM)).toBe(false);
+      expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
+    });
+
+    it('overwrites an existing travel param value', () => {
+      mockSearchParamsFrom(`${TRAVEL_PARAM}=false`);
+      setLocation(`https://example.com/vendors?${TRAVEL_PARAM}=false`);
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setParams({ [TRAVEL_PARAM]: 'true' });
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      expect(url.searchParams.get(TRAVEL_PARAM)).toBe('true');
+    });
+
+    it('produces a bare pathname (no trailing "?") when the last param is cleared', () => {
+      mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup`);
+      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup`);
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setParams({ [SKILL_PARAM]: null });
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      expect(calledUrl).toBe('/vendors');
+    });
+
+    it('reads from window.location.search at call time, not from a stale searchParams closure', () => {
+      // Simulates the production race: React's searchParams hasn't caught up yet
+      // (still shows only the skill filter), but the browser's actual URL has
+      // already moved on to include a location, from a prior replace() that
+      // hasn't triggered a re-render yet.
+      mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup`); // stale value React still has
+      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127&${LONGITUDE_PARAM}=-74.006`); // actual current URL
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setParams({ [SERVICE_PARAM]: 'Makeup' });
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      // lat/lon should be preserved because they came from window.location, not stale searchParams
+      expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
+      expect(url.searchParams.get(LONGITUDE_PARAM)).toBe('-74.006');
+      expect(url.searchParams.get(SKILL_PARAM)).toBe('Thai Makeup');
+      expect(url.searchParams.get(SERVICE_PARAM)).toBe('Makeup');
+    });
+
+    it('uses router.replace, not router.push', () => {
+      mockSearchParamsFrom('');
+      setLocation('https://example.com/vendors');
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setParams({ [SKILL_PARAM]: 'Thai Makeup' });
+      });
+
+      expect(replaceMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('setParam', () => {
+    it('delegates to setParams with a single key', () => {
+      mockSearchParamsFrom(`${LATITUDE_PARAM}=40.7127`);
+      setLocation(`https://example.com/vendors?${LATITUDE_PARAM}=40.7127`);
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setParam(SERVICE_PARAM, 'Hair');
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      expect(url.searchParams.get(SERVICE_PARAM)).toBe('Hair');
+      expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
+    });
+  });
+
+  describe('setArrayParam', () => {
+    it('sets multiple skill values as repeated params', () => {
+      mockSearchParamsFrom('');
+      setLocation('https://example.com/vendors');
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setArrayParam(SKILL_PARAM, ['Thai Makeup', 'South Asian Makeup']);
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      expect(url.searchParams.getAll(SKILL_PARAM)).toEqual(['Thai Makeup', 'South Asian Makeup']);
+    });
+
+    it('removes all instances of the skill param when values is null', () => {
+      mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup&${LATITUDE_PARAM}=40.7127`);
+      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup&${LATITUDE_PARAM}=40.7127`);
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setArrayParam(SKILL_PARAM, null);
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      expect(url.searchParams.getAll(SKILL_PARAM)).toEqual([]);
+      expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
+    });
+
+    it('removes all instances of the skill param when values is an empty array', () => {
+      mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setArrayParam(SKILL_PARAM, []);
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      expect(url.searchParams.getAll(SKILL_PARAM)).toEqual([]);
+    });
+
+    it('replaces existing repeated skill values rather than appending to them', () => {
+      mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setArrayParam(SKILL_PARAM, ['South Asian Makeup']);
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      expect(url.searchParams.getAll(SKILL_PARAM)).toEqual(['South Asian Makeup']);
+    });
+
+    it('removing one skill from a multi-skill selection preserves the others as separate params (not comma-joined)', () => {
+      mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+
+      const { result } = renderHook(() => useURLFilters());
+      act(() => {
+        result.current.setArrayParam(SKILL_PARAM, ['South Asian Makeup']);
+      });
+
+      const [calledUrl] = replaceMock.mock.calls[0];
+      const url = new URL(calledUrl, 'https://example.com');
+      // Guards against the comma-join bug (?skill=South Asian Makeup,Thai Makeup as one value)
+      expect(url.searchParams.getAll(SKILL_PARAM)).toEqual(['South Asian Makeup']);
+      expect(url.searchParams.getAll(SKILL_PARAM)).not.toContain('Thai Makeup,South Asian Makeup');
+    });
+  });
+});

--- a/frontend/src/hooks/useURLFilters.test.ts
+++ b/frontend/src/hooks/useURLFilters.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useURLFilters } from './useURLFilters';
 import {
   TRAVEL_PARAM,
@@ -13,6 +13,7 @@ import {
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(),
   useSearchParams: vi.fn(),
+  usePathname: vi.fn(),
 }));
 
 function setLocation(url: string) {
@@ -31,6 +32,9 @@ describe('useURLFilters', () => {
       replace: replaceMock,
       push: vi.fn(),
     });
+    // Every test in this suite operates on /vendors; usePathname must reflect
+    // that or buildUrl() has no pathname to prepend to the query string.
+    (usePathname as ReturnType<typeof vi.fn>).mockReturnValue('/vendors');
   });
 
   function mockSearchParamsFrom(search: string) {
@@ -42,7 +46,7 @@ describe('useURLFilters', () => {
   describe('getParam / getAllParams', () => {
     it('reads a single service param value', () => {
       mockSearchParamsFrom(`${SERVICE_PARAM}=Makeup`);
-      setLocation(`https://example.com/vendors?${SERVICE_PARAM}=Makeup`);
+      setLocation(`https://wwww.asianweddingmakeup.com/vendors?${SERVICE_PARAM}=Makeup`);
 
       const { result } = renderHook(() => useURLFilters());
       expect(result.current.getParam(SERVICE_PARAM)).toBe('Makeup');
@@ -50,7 +54,7 @@ describe('useURLFilters', () => {
 
     it('returns null for a missing param', () => {
       mockSearchParamsFrom('');
-      setLocation('https://example.com/vendors');
+      setLocation('https://wwww.asianweddingmakeup.com/vendors');
 
       const { result } = renderHook(() => useURLFilters());
       expect(result.current.getParam(SKILL_PARAM)).toBeNull();
@@ -58,7 +62,7 @@ describe('useURLFilters', () => {
 
     it('reads all values for a repeated skill param', () => {
       mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
-      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+      setLocation(`https://wwww.asianweddingmakeup.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
 
       const { result } = renderHook(() => useURLFilters());
       expect(result.current.getAllParams(SKILL_PARAM)).toEqual(['Thai Makeup', 'South Asian Makeup']);
@@ -68,7 +72,7 @@ describe('useURLFilters', () => {
   describe('paramsString', () => {
     it('mirrors the current searchParams as a string', () => {
       mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127`);
-      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127`);
+      setLocation(`https://wwww.asianweddingmakeup.com/vendors?${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127`);
 
       const { result } = renderHook(() => useURLFilters());
       expect(result.current.paramsString).toBe(`${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127`);
@@ -76,7 +80,7 @@ describe('useURLFilters', () => {
 
     it('is an empty string when there are no params', () => {
       mockSearchParamsFrom('');
-      setLocation('https://example.com/vendors');
+      setLocation('https://www.asianweddingmakeup.com/vendors');
 
       const { result } = renderHook(() => useURLFilters());
       expect(result.current.paramsString).toBe('');
@@ -86,7 +90,7 @@ describe('useURLFilters', () => {
   describe('setParams', () => {
     it('adds a new skill filter while preserving an existing location filter', () => {
       mockSearchParamsFrom(`${LATITUDE_PARAM}=40.7127&${LONGITUDE_PARAM}=-74.006`);
-      setLocation(`https://example.com/vendors?${LATITUDE_PARAM}=40.7127&${LONGITUDE_PARAM}=-74.006`);
+      setLocation(`https://wwww.asianweddingmakeup.com/vendors?${LATITUDE_PARAM}=40.7127&${LONGITUDE_PARAM}=-74.006`);
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -95,7 +99,7 @@ describe('useURLFilters', () => {
 
       expect(replaceMock).toHaveBeenCalledOnce();
       const [calledUrl, options] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://wwww.asianweddingmakeup.com');
       expect(url.pathname).toBe('/vendors');
       expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
       expect(url.searchParams.get(LONGITUDE_PARAM)).toBe('-74.006');
@@ -105,7 +109,7 @@ describe('useURLFilters', () => {
 
     it('removes a service param when value is null', () => {
       mockSearchParamsFrom(`${SERVICE_PARAM}=Hair&${LATITUDE_PARAM}=40.7127`);
-      setLocation(`https://example.com/vendors?${SERVICE_PARAM}=Hair&${LATITUDE_PARAM}=40.7127`);
+      setLocation(`https://wwww.asianweddingmakeup.com/vendors?${SERVICE_PARAM}=Hair&${LATITUDE_PARAM}=40.7127`);
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -113,14 +117,14 @@ describe('useURLFilters', () => {
       });
 
       const [calledUrl] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://www.asianweddingmakeup.com');
       expect(url.searchParams.has(SERVICE_PARAM)).toBe(false);
       expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
     });
 
     it('overwrites an existing travel param value', () => {
       mockSearchParamsFrom(`${TRAVEL_PARAM}=false`);
-      setLocation(`https://example.com/vendors?${TRAVEL_PARAM}=false`);
+      setLocation(`https://www.asianweddingmakeup.com/vendors?${TRAVEL_PARAM}=false`);
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -128,13 +132,13 @@ describe('useURLFilters', () => {
       });
 
       const [calledUrl] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://www.asianweddingmakeup.com');
       expect(url.searchParams.get(TRAVEL_PARAM)).toBe('true');
     });
 
     it('produces a bare pathname (no trailing "?") when the last param is cleared', () => {
       mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup`);
-      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup`);
+      setLocation(`https://www.asianweddingmakeup.com/vendors?${SKILL_PARAM}=Thai+Makeup`);
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -151,7 +155,7 @@ describe('useURLFilters', () => {
       // already moved on to include a location, from a prior replace() that
       // hasn't triggered a re-render yet.
       mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup`); // stale value React still has
-      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127&${LONGITUDE_PARAM}=-74.006`); // actual current URL
+      setLocation(`https://www.asianweddingmakeup.com/vendors?${SKILL_PARAM}=Thai+Makeup&${LATITUDE_PARAM}=40.7127&${LONGITUDE_PARAM}=-74.006`); // actual current URL
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -159,7 +163,7 @@ describe('useURLFilters', () => {
       });
 
       const [calledUrl] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://www.asianweddingmakeup.com');
       // lat/lon should be preserved because they came from window.location, not stale searchParams
       expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
       expect(url.searchParams.get(LONGITUDE_PARAM)).toBe('-74.006');
@@ -169,7 +173,7 @@ describe('useURLFilters', () => {
 
     it('uses router.replace, not router.push', () => {
       mockSearchParamsFrom('');
-      setLocation('https://example.com/vendors');
+      setLocation('https://www.asianweddingmakeup.com/vendors');
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -183,7 +187,7 @@ describe('useURLFilters', () => {
   describe('setParam', () => {
     it('delegates to setParams with a single key', () => {
       mockSearchParamsFrom(`${LATITUDE_PARAM}=40.7127`);
-      setLocation(`https://example.com/vendors?${LATITUDE_PARAM}=40.7127`);
+      setLocation(`https://www.asianweddingmakeup.com/vendors?${LATITUDE_PARAM}=40.7127`);
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -191,7 +195,7 @@ describe('useURLFilters', () => {
       });
 
       const [calledUrl] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://www.asianweddingmakeup.com');
       expect(url.searchParams.get(SERVICE_PARAM)).toBe('Hair');
       expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
     });
@@ -200,7 +204,7 @@ describe('useURLFilters', () => {
   describe('setArrayParam', () => {
     it('sets multiple skill values as repeated params', () => {
       mockSearchParamsFrom('');
-      setLocation('https://example.com/vendors');
+      setLocation('https://www.asianweddingmakeup.com/vendors');
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -208,13 +212,13 @@ describe('useURLFilters', () => {
       });
 
       const [calledUrl] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://www.asianweddingmakeup.com');
       expect(url.searchParams.getAll(SKILL_PARAM)).toEqual(['Thai Makeup', 'South Asian Makeup']);
     });
 
     it('removes all instances of the skill param when values is null', () => {
       mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup&${LATITUDE_PARAM}=40.7127`);
-      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup&${LATITUDE_PARAM}=40.7127`);
+      setLocation(`https://www.asianweddingmakeup.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup&${LATITUDE_PARAM}=40.7127`);
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -222,14 +226,14 @@ describe('useURLFilters', () => {
       });
 
       const [calledUrl] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://www.asianweddingmakeup.com');
       expect(url.searchParams.getAll(SKILL_PARAM)).toEqual([]);
       expect(url.searchParams.get(LATITUDE_PARAM)).toBe('40.7127');
     });
 
     it('removes all instances of the skill param when values is an empty array', () => {
       mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
-      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+      setLocation(`https://www.asianweddingmakeup.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -237,13 +241,13 @@ describe('useURLFilters', () => {
       });
 
       const [calledUrl] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://www.asianweddingmakeup.com');
       expect(url.searchParams.getAll(SKILL_PARAM)).toEqual([]);
     });
 
     it('replaces existing repeated skill values rather than appending to them', () => {
       mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
-      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+      setLocation(`https://www.asianweddingmakeup.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -251,13 +255,13 @@ describe('useURLFilters', () => {
       });
 
       const [calledUrl] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://www.asianweddingmakeup.com');
       expect(url.searchParams.getAll(SKILL_PARAM)).toEqual(['South Asian Makeup']);
     });
 
     it('removing one skill from a multi-skill selection preserves the others as separate params (not comma-joined)', () => {
       mockSearchParamsFrom(`${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
-      setLocation(`https://example.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
+      setLocation(`https://www.asianweddingmakeup.com/vendors?${SKILL_PARAM}=Thai+Makeup&${SKILL_PARAM}=South+Asian+Makeup`);
 
       const { result } = renderHook(() => useURLFilters());
       act(() => {
@@ -265,7 +269,7 @@ describe('useURLFilters', () => {
       });
 
       const [calledUrl] = replaceMock.mock.calls[0];
-      const url = new URL(calledUrl, 'https://example.com');
+      const url = new URL(calledUrl, 'https://www.asianweddingmakeup.com');
       // Guards against the comma-join bug (?skill=South Asian Makeup,Thai Makeup as one value)
       expect(url.searchParams.getAll(SKILL_PARAM)).toEqual(['South Asian Makeup']);
       expect(url.searchParams.getAll(SKILL_PARAM)).not.toContain('Thai Makeup,South Asian Makeup');

--- a/frontend/src/hooks/useURLFilters.ts
+++ b/frontend/src/hooks/useURLFilters.ts
@@ -46,7 +46,7 @@ export function useURLFilters() {
       // so applying a filter never bounces the user to a different route.
       const targetPath = pathnameRef.current;
       const newUrl = search ? `${targetPath}?${search}` : targetPath;
-      router.push(newUrl, { scroll: false });
+      router.replace(newUrl, { scroll: false });
     },
     [router]
   );
@@ -69,7 +69,7 @@ export function useURLFilters() {
       const search = newParams.toString();
       const targetPath = pathnameRef.current;
       const newUrl = search ? `${targetPath}?${search}` : targetPath;
-      router.push(newUrl, { scroll: false });
+      router.replace(newUrl, { scroll: false });
     },
     [router]
   );

--- a/frontend/src/hooks/useURLFilters.ts
+++ b/frontend/src/hooks/useURLFilters.ts
@@ -1,16 +1,15 @@
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo } from "react";
 
-
-function buildUrl(newParams: URLSearchParams): string {
+function buildUrl(pathname: string, newParams: URLSearchParams): string {
   const search = newParams.toString();
-  const pathname = window.location.pathname;
   return search ? `${pathname}?${search}` : pathname;
 }
 
 export function useURLFilters() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const pathname = usePathname() || '';
 
   const paramsString = useMemo(() => searchParams?.toString() ?? "", [searchParams]);
 
@@ -35,9 +34,9 @@ export function useURLFilters() {
           newParams.set(key, value);
         }
       });
-      router.replace(buildUrl(newParams), { scroll: false });
+      router.replace(buildUrl(pathname, newParams), { scroll: false });
     },
-    [router]
+    [router, pathname]
   );
 
   const setParam = useCallback(
@@ -55,9 +54,9 @@ export function useURLFilters() {
       if (values && values.length > 0) {
         values.forEach(value => newParams.append(key, value));
       }
-      router.replace(buildUrl(newParams), { scroll: false });
+      router.replace(buildUrl(pathname, newParams), { scroll: false });
     },
-    [router]
+    [router, pathname]
   );
 
   return {

--- a/frontend/src/hooks/useURLFilters.ts
+++ b/frontend/src/hooks/useURLFilters.ts
@@ -1,25 +1,19 @@
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+
+
+function buildUrl(newParams: URLSearchParams): string {
+  const search = newParams.toString();
+  const pathname = window.location.pathname;
+  return search ? `${pathname}?${search}` : pathname;
+}
 
 export function useURLFilters() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const pathname = usePathname() || ''; // SSR-safe
 
-  // Store the latest values in refs to avoid recreating callbacks
-  const searchParamsRef = useRef(searchParams);
-  const pathnameRef = useRef(pathname);
-
-  // Update refs on every render
-  useEffect(() => {
-    searchParamsRef.current = searchParams;
-    pathnameRef.current = pathname;
-  });
-
-  // Return a stable string version to memoize dependencies
   const paramsString = useMemo(() => searchParams?.toString() ?? "", [searchParams]);
 
-  // stable callbacks using refs
   const getParam = useCallback(
     (key: string) => searchParams?.get(key),
     [searchParams]
@@ -32,8 +26,8 @@ export function useURLFilters() {
 
   const setParams = useCallback(
     (updates: Record<string, string | null>) => {
-      const currentParams = searchParamsRef.current?.toString() ?? "";
-      const newParams = new URLSearchParams(currentParams);
+      const currentSearch = typeof window !== 'undefined' ? window.location.search : '';
+      const newParams = new URLSearchParams(currentSearch);
       Object.entries(updates).forEach(([key, value]) => {
         if (value === null) {
           newParams.delete(key);
@@ -41,12 +35,7 @@ export function useURLFilters() {
           newParams.set(key, value);
         }
       });
-      const search = newParams.toString();
-      // Always stay on the current page (e.g. /vendors or a /[location] page)
-      // so applying a filter never bounces the user to a different route.
-      const targetPath = pathnameRef.current;
-      const newUrl = search ? `${targetPath}?${search}` : targetPath;
-      router.replace(newUrl, { scroll: false });
+      router.replace(buildUrl(newParams), { scroll: false });
     },
     [router]
   );
@@ -60,16 +49,13 @@ export function useURLFilters() {
 
   const setArrayParam = useCallback(
     (key: string, values: string[] | null) => {
-      const currentParams = searchParamsRef.current?.toString() ?? "";
-      const newParams = new URLSearchParams(currentParams);
+      const currentSearch = typeof window !== 'undefined' ? window.location.search : '';
+      const newParams = new URLSearchParams(currentSearch);
       newParams.delete(key);
       if (values && values.length > 0) {
         values.forEach(value => newParams.append(key, value));
       }
-      const search = newParams.toString();
-      const targetPath = pathnameRef.current;
-      const newUrl = search ? `${targetPath}?${search}` : targetPath;
-      router.replace(newUrl, { scroll: false });
+      router.replace(buildUrl(newParams), { scroll: false });
     },
     [router]
   );

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -12,6 +12,8 @@ export const QUERY_PARAM = 'q';
 export const LATITUDE_PARAM = 'lat';
 export const LONGITUDE_PARAM = 'lon';
 
+export const DIRECTORY_FILTER_PARAMS = [SEARCH_PARAM, LOCATION_PARAM, TRAVEL_PARAM, SKILL_PARAM, SERVICE_PARAM, LATITUDE_PARAM, LONGITUDE_PARAM];
+
 // magic link params
 export const SLUG_PARAM = 'slug';
 export const EMAIL_PARAM = 'email';

--- a/frontend/src/lib/redirect/directoryRedirect.test.ts
+++ b/frontend/src/lib/redirect/directoryRedirect.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { getDirectoryRedirect } from './directoryRedirect';
+import { LATITUDE_PARAM, LONGITUDE_PARAM, SEARCH_PARAM, TRAVEL_PARAM, SKILL_PARAM, SERVICE_PARAM } from '../constants';
+
+function makeRequest(url: string) {
+  return new NextRequest(new Request(url));
+}
+
+describe('getDirectoryRedirect', () => {
+  it('redirects homepage with a location param to /directory, preserving params', () => {
+    const req = makeRequest('https://www.asianweddingmakeup.com?lat=37.7793&lon=-122.4193');
+    const res = getDirectoryRedirect(req);
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(301);
+    expect(res!.headers.get('location')).toBe('https://www.asianweddingmakeup.com/vendors?lat=37.7793&lon=-122.4193');
+  });
+
+  it('preserves multiple params', () => {
+    const req = makeRequest('https://www.asianweddingmakeup.com?query=makeup&lat=34.0537&lon=-118.2428&service=Makeup&skill=South+Asian+Makeup&travelsWorldwide=true');
+    const res = getDirectoryRedirect(req);
+
+    const redirectUrl = new URL(res!.headers.get('location')!);
+    expect(redirectUrl.pathname).toBe('/vendors');
+    expect(redirectUrl.searchParams.get(LATITUDE_PARAM)).toBe('34.0537');
+    expect(redirectUrl.searchParams.get(LONGITUDE_PARAM)).toBe('-118.2428');
+    expect(redirectUrl.searchParams.get(SEARCH_PARAM)).toBe('makeup');
+    expect(redirectUrl.searchParams.get(SERVICE_PARAM)).toBe('Makeup');
+    expect(redirectUrl.searchParams.get(SKILL_PARAM)).toBe('South Asian Makeup');
+    expect(redirectUrl.searchParams.get(TRAVEL_PARAM)).toBe('true');
+  });
+
+  it('does not redirect the homepage with no filter params', () => {
+    const req = makeRequest('https://www.asianweddingmakeup.com/');
+    expect(getDirectoryRedirect(req)).toBeNull();
+  });
+
+  it('does not redirect the homepage with an unrelated param', () => {
+    const req = makeRequest('https://www.asianweddingmakeup.com/?utm_source=reddit');
+    expect(getDirectoryRedirect(req)).toBeNull();
+  });
+
+  it('does not redirect non-homepage paths even with filter params', () => {
+    const req = makeRequest('https://www.asianweddingmakeup.com/some-other-page?lat=40.7127&lon=-74.006');
+    expect(getDirectoryRedirect(req)).toBeNull();
+  });
+
+  it('does not redirect the directory page itself', () => {
+    const req = makeRequest('https://www.asianweddingmakeup.com/vendors?lat=40.7127&lon=-74.006');
+    expect(getDirectoryRedirect(req)).toBeNull();
+  });
+});

--- a/frontend/src/lib/redirect/directoryRedirect.ts
+++ b/frontend/src/lib/redirect/directoryRedirect.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { DIRECTORY_FILTER_PARAMS } from '../constants';
+
+/**
+ * If the homepage is hit with directory-filter params,
+ * redirect to the directory page, preserving all query params.
+ * Returns null if no redirect is needed.
+ */
+export function getDirectoryRedirect(request: NextRequest): NextResponse | null {
+  const { pathname, searchParams } = request.nextUrl;
+
+  console.log('getDirectoryRedirect: pathname', pathname);
+  if (pathname !== '/') {
+    return null;
+  }
+
+  console.log('getDirectoryRedirect: searchParams', searchParams);
+
+  const hasDirectoryFilter = DIRECTORY_FILTER_PARAMS.some((param) =>
+    searchParams.has(param)
+  );
+
+  console.log('getDirectoryRedirect: hasDirectoryFilter', hasDirectoryFilter);
+
+  if (!hasDirectoryFilter) {
+    return null;
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = '/vendors';
+  return NextResponse.redirect(url, 301);
+}

--- a/frontend/src/lib/redirect/directoryRedirect.ts
+++ b/frontend/src/lib/redirect/directoryRedirect.ts
@@ -9,18 +9,13 @@ import { DIRECTORY_FILTER_PARAMS } from '../constants';
 export function getDirectoryRedirect(request: NextRequest): NextResponse | null {
   const { pathname, searchParams } = request.nextUrl;
 
-  console.log('getDirectoryRedirect: pathname', pathname);
   if (pathname !== '/') {
     return null;
   }
 
-  console.log('getDirectoryRedirect: searchParams', searchParams);
-
   const hasDirectoryFilter = DIRECTORY_FILTER_PARAMS.some((param) =>
     searchParams.has(param)
   );
-
-  console.log('getDirectoryRedirect: hasDirectoryFilter', hasDirectoryFilter);
 
   if (!hasDirectoryFilter) {
     return null;

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -1,0 +1,22 @@
+import { it, expect, vi } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+vi.mock('@/lib/supabase/middleware', () => ({
+  updateSession: vi.fn(async () => NextResponse.next()),
+}));
+import { updateSession } from '@/lib/supabase/middleware';
+import { proxy } from './proxy';
+
+it('skips updateSession when a directory redirect fires', async () => {
+  const req = new NextRequest(new Request('https://www.asianweddingmakeup.com/?lat=37.7793&lon=-122.4193'));
+  const res = await proxy(req);
+
+  expect(res.status).toBe(301);
+  expect(updateSession).not.toHaveBeenCalled();
+});
+
+it('calls updateSession when no redirect is needed', async () => {
+  const req = new NextRequest(new Request('https://www.asianweddingmakeup.com/'));
+  await proxy(req);
+
+  expect(updateSession).toHaveBeenCalledOnce();
+});

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -1,10 +1,12 @@
-import { it, expect, vi } from 'vitest';
+import { it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
+import { updateSession } from '@/lib/supabase/middleware';
+import { proxy } from './proxy';
+
 vi.mock('@/lib/supabase/middleware', () => ({
   updateSession: vi.fn(async () => NextResponse.next()),
 }));
-import { updateSession } from '@/lib/supabase/middleware';
-import { proxy } from './proxy';
+beforeEach(() => vi.clearAllMocks());
 
 it('skips updateSession when a directory redirect fires', async () => {
   const req = new NextRequest(new Request('https://www.asianweddingmakeup.com/?lat=37.7793&lon=-122.4193'));

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,11 +1,17 @@
 import { type NextRequest } from 'next/server';
 import { updateSession } from '@/lib/supabase/middleware';
+import { getDirectoryRedirect } from './lib/redirect/directoryRedirect';
 
 
 /**
  * Next.js middleware entry point — runs on every matched request before any route renders.
  */
 export async function proxy(request: NextRequest) {
+  const redirect = getDirectoryRedirect(request);
+  if (redirect) {
+    return redirect;
+  }
+
   return await updateSession(request);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added homepage-to-vendor directory redirect when directory filter parameters are present, preserving relevant query parameters.
  * Ensured active filter “chips” render on redirected and direct directory visits and can be cleared.
* **Bug Fixes**
  * Prevented redirects for unfiltered homepage and when already on the directory page, including preservation of existing directory URLs.
  * Updated filter navigation to replace the current browser history entry (instead of adding a new one).
* **Tests**
  * Expanded Playwright E2E to verify redirect + filter-state behavior.
  * Added/updated unit and middleware tests covering redirect and session update handling.
* **Chores**
  * Minor testability/UI markup and cleanup (e.g., active-filters test hook, removed unused React import).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->