### PR TITLE
remove lat and lon guard

### DIFF
--- a/frontend/src/features/directory/hooks/useVendorFiltering.ts
+++ b/frontend/src/features/directory/hooks/useVendorFiltering.ts
@@ -47,32 +47,6 @@ export const useVendorFiltering = ({
         return;
       }
 
-      // Guard against stale selectedLocation only when we actually have a
-      // selectedLocation to compare against. If it's null (genuinely
-      // resolved to "not found"), there's nothing to compare, so fall
-      // through to the hasValidLocation check below instead of bailing here.
-      if (urlLat && urlLon && selectedLocation) {
-        const urlLatNum = parseFloat(urlLat);
-        const urlLonNum = parseFloat(urlLon);
-        const locationLat = selectedLocation.lat;
-        const locationLon = selectedLocation.lon;
-
-        // Only proceed if locationLat and locationLon are defined
-        if (locationLat === undefined || locationLat === null || locationLon === undefined || locationLon === null) {
-          console.debug('Location latitude or longitude is undefined, skipping fetch.');
-          return;
-        }
-
-        // Allow for small floating point differences
-        const latMatch = Math.abs(urlLatNum - locationLat) < 0.0001;
-        const lonMatch = Math.abs(urlLonNum - locationLon) < 0.0001;
-
-        if (!latMatch || !lonMatch) {
-          console.debug('Location/URL mismatch, skipping fetch. URL:', { urlLatNum, urlLonNum }, 'Location:', { locationLat, locationLon });
-          return; // Skip fetch, location is still resolving to a different point
-        }
-      }
-
       // Check if we have a valid location with required properties
       const hasValidLocation = selectedLocation &&
         selectedLocation.display_name &&


### PR DESCRIPTION
### Bug
Certain locations like Washington DC don't resolve properly. For example, the table will be stuck in "Loading" https://www.asianweddingmakeup.com/vendors?lat=38.895&lon=-77.0365

### Root Cause
useResolvedLocation has a branch guarding against this scenario: "URL params just changed to a new location, but selectedLocation hasn't caught up yet, don't fetch against a stale mismatch". To do this, the branch checks if URL's lat and lon match the selectedLocation's lat and lon, with a small allowance for precision differences. If they are different, return early to avoid the fetch. 

The bug is that the URL location resolves to a selectedLocation based on the NEAREST photon geocoding feature. In Washington DC, this was just outside the small allowance, so it was incorrectly flagged as a mismatch.  

### Fix

The branch is not actually necessary anymore because the scenario is now handled, upstream, by useResolvedLocation's coords-key tracking:

1. The moment the URL's lat/lon change, coordsKey changes.
2. useResolvedLocation only returns a resolved value when resolvedFromFetch.key === coordsKey for the current coords.
3. If that key doesn't match (i.e. you just navigated to a new spot and the old resolution is stale), it returns undefined, not the stale location.
4. That flows straight into isLocationResolving = true, which useVendorFiltering already checks and bails out on, correctly, before this block even runs. 

So we can safely delete the guard with the bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vendor directory loading by preventing outdated location data from blocking valid vendor searches.
  * Vendor results now load more reliably after location changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->