### PR TITLE
dedupe e2e tests that don't use mobile layouts

### DIFF
--- a/frontend/e2e/auth/login.public.spec.ts
+++ b/frontend/e2e/auth/login.public.spec.ts
@@ -4,7 +4,7 @@ import { userWorkerAccounts } from '../fixtures/testUsers';
 
 const { email, password } = userWorkerAccounts[0];
 
-test.describe('Login — guest', () => {
+test.describe('Login — guest', { tag: '@mobile' }, () => {
   test('login page renders with email, password, and submit button', async ({ page }) => {
     await page.goto('/login');
     await expect(page.getByLabel('Email Address')).toBeVisible();

--- a/frontend/e2e/favorites/favorites.auth.spec.ts
+++ b/frontend/e2e/favorites/favorites.auth.spec.ts
@@ -42,7 +42,7 @@ async function clickFavoriteAndPersist(page: Page, button: Locator): Promise<voi
 // eslint-disable-next-line react-hooks/rules-of-hooks
 test.use({ storageState: ({ userWorkerStorageState }, use) => use(userWorkerStorageState) });
 
-test.describe.serial('Favorites — authenticated', () => {
+test.describe.serial('Favorites — authenticated', { tag: '@mobile' }, () => {
   test.beforeAll(async ({ browser, userWorkerStorageState }) => {
     const context = await browser.newContext({
       storageState: userWorkerStorageState,

--- a/frontend/e2e/favorites/favorites.public.spec.ts
+++ b/frontend/e2e/favorites/favorites.public.spec.ts
@@ -12,7 +12,7 @@ import { refreshVendors } from '../fixtures/devToolHelpers';
 
 const GLAMOUR_SLUG = 'test-glamour-studio';
 
-test.describe('Favorites — guest', () => {
+test.describe('Favorites — guest', { tag: '@mobile' }, () => {
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
     await page.goto('/');

--- a/frontend/e2e/smoke/blog.public.spec.ts
+++ b/frontend/e2e/smoke/blog.public.spec.ts
@@ -194,7 +194,7 @@ test.describe('Blog page layout', { tag: '@mobile' }, () => {
   });
 });
 
-test.describe('Featured post image layout', () => {
+test.describe('Featured post image layout', { tag: '@mobile' }, () => {
   test('featured post with landscape image uses column layout on mobile', async ({ page }) => {
     // Set a mobile viewport
     await page.setViewportSize({ width: 375, height: 812 });

--- a/frontend/e2e/smoke/blog.public.spec.ts
+++ b/frontend/e2e/smoke/blog.public.spec.ts
@@ -14,7 +14,7 @@ import { test, expect } from '@playwright/test';
  *   4. "Test Portrait Bridal Shoot"        — wedding-inspo, vietnamese, california           (portrait 600x900)
  */
 
-test.describe('Blog page layout', () => {
+test.describe('Blog page layout', { tag: '@mobile' }, () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/blog');
     await expect(page.getByRole('heading', { name: 'Blog', level: 1 })).toBeVisible();

--- a/frontend/e2e/smoke/landing-page.public.spec.ts
+++ b/frontend/e2e/smoke/landing-page.public.spec.ts
@@ -71,6 +71,13 @@ test.describe('Landing page — guest', () => {
     await viewAll.click();
     await expect(page).toHaveURL('/blog');
   });
+});
+
+
+test.describe('Landing page — carousel overflow', { tag: '@mobile' }, () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
 
   test('carousel scroll arrow advances content when overflowing', async ({ page }) => {
     // The generic Carousel exposes arrows via aria-label. They only appear when
@@ -81,8 +88,8 @@ test.describe('Landing page — guest', () => {
       test.skip(true, 'No overflowing carousel on this viewport / dataset');
     }
 
-    await scrollRight.click();
     // After scrolling right, the left-scroll affordance should appear.
+    await scrollRight.click();
     await expect(
       page.getByRole('button', { name: 'Scroll left' }).first()
     ).toBeVisible();

--- a/frontend/e2e/smoke/vendor-directory.public.spec.ts
+++ b/frontend/e2e/smoke/vendor-directory.public.spec.ts
@@ -11,7 +11,7 @@ import { refreshVendors } from '../fixtures/devToolHelpers';
  *       tags: Hair (service, style=primary)
  */
 
-test.describe('Vendor directory — guest', () => {
+test.describe('Vendor directory — guest', { tag: '@mobile' }, () => {
   test.beforeAll(async ({ browser }) => {
     // After supabase db reset the Next.js unstable_cache is stale.
     // Click the DevTools "Refresh Vendors" button (dev-only) to revalidate it

--- a/frontend/e2e/vendor/profile-edit.vendor.protected.spec.ts
+++ b/frontend/e2e/vendor/profile-edit.vendor.protected.spec.ts
@@ -15,7 +15,7 @@ import { DESKTOP_ONLY_DESCRIPTION } from '../constants';
 // eslint-disable-next-line react-hooks/rules-of-hooks
 test.use({ storageState: ({ vendorWorkerStorageState }, use) => use(vendorWorkerStorageState) });
 
-test.describe('Vendor Profile Editor', () => {
+test.describe('Vendor Profile Editor', { tag: '@mobile' }, () => {
   test.beforeEach(async ({ page, isMobile }) => {
     // Dismiss the "Use desktop for best experience" overlay on mobile
     // before it can block interactions. The overlay checks sessionStorage,

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
       },
       dependencies: ['supabase-setup'],
       testMatch: '**/e2e/**/*.auth.spec.ts',
+      grep: /@mobile/,   // only run tests explicitly tagged for mobile
     },
 
     // -----------------------------------------------------------------
@@ -102,6 +103,7 @@ export default defineConfig({
       },
       dependencies: ['supabase-setup'],
       testMatch: '**/e2e/**/*.vendor.protected.spec.ts',
+      grep: /@mobile/,   // only run tests explicitly tagged for mobile
     },
 
     // -----------------------------------------------------------------
@@ -118,6 +120,7 @@ export default defineConfig({
       use: { ...devices['iPhone 15'] },
       dependencies: ['supabase-setup'],
       testMatch: '**/e2e/**/*.public.spec.ts',
+      grep: /@mobile/,   // only run tests explicitly tagged for mobile
     },
     {
       name: 'api',


### PR DESCRIPTION
Our e2e tests have been getting flakier with more frequent time outs. Most tests are run twice: once on web and once on mobile. This PR dedupes tests that are unnecessary to run on both.

### Changes
* Tests will be run with the web browser by default
* @mobile tag is added to  tests that should ALSO be run on mobile