### PR TITLE
improve json-ld for auxiliary pages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1000.0",
         "@behold/react": "^0.1.11",
+        "@contentful/rich-text-plain-text-renderer": "^17.2.1",
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "@contentful/rich-text-types": "^17.2.7",
         "@emotion/cache": "^11.14.0",
@@ -795,6 +796,18 @@
       "dependencies": {
         "@vercel/stega": "^0.1.2",
         "json-pointer": "^0.6.2"
+      }
+    },
+    "node_modules/@contentful/rich-text-plain-text-renderer": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-17.2.1.tgz",
+      "integrity": "sha512-GsuDPOs1dR3VOW3dWFzMqdXKrwceCSusKIttHMjGKM6yNUkf5MSOOsWR/MIUVxbFyFeAqEFMZ4LSDkeFvzL8Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^17.2.7"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@contentful/rich-text-react-renderer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1000.0",
     "@behold/react": "^0.1.11",
+    "@contentful/rich-text-plain-text-renderer": "^17.2.1",
     "@contentful/rich-text-react-renderer": "^16.0.1",
     "@contentful/rich-text-types": "^17.2.7",
     "@emotion/cache": "^11.14.0",

--- a/frontend/src/app/(public)/blog/[slug]/page.tsx
+++ b/frontend/src/app/(public)/blog/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { ORG_ID, PHOTO_WEBSITE_PREVIEW_URL, SITE_URL } from '@/seo/constants';
 import { richTextToPlainText } from '@/seo/articlePlaintext';
 import { jsonLdGraph, sanitizeJsonLdHtml } from '@/seo/jsonLdHtml';
 import { BlogPosting } from 'schema-dts';
+import { notFound } from 'next/dist/client/components/navigation';
 
 type Props = {
   params: Promise<{ slug: string }>
@@ -82,8 +83,12 @@ export default async function BlogPostPage({ params }: Props) {
   const { slug } = await params;
   const post = await getPostBySlug(slug);
 
+  if (!post) {
+    notFound();
+  }
+
   // Gate future posts
-  if (post && !isPublishedInEasternTime(post.publishedDate)) {
+  if (!isPublishedInEasternTime(post.publishedDate)) {
     // Must be inside the component to run at request time for only future posts
     const { cookies } = await import('next/headers');
     const cookieStore = await cookies();

--- a/frontend/src/app/(public)/blog/[slug]/page.tsx
+++ b/frontend/src/app/(public)/blog/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import { Metadata } from 'next';
 import { getPostBySlug } from '@/features/blog/api/getBlogPosts';
-import previewImage from '@/assets/website_preview.jpeg';
 import { isPublishedInEasternTime } from '@/lib/dateUtils';
 import Article from '@/features/blog/components/Article';
 import Scroll from '@/components/ui/Scroll';
@@ -9,6 +8,10 @@ import Spotlight from '@/features/blog/components/Spotlight';
 import PasswordGate from '@/components/ui/PasswordGate';
 import { graphQLClient } from '@/lib/contentful/graphqlClient';
 import { GetAllBlogPostsDocument, GetAllBlogPostsQuery } from '@/lib/generated/graphql';
+import { ORG_ID, PHOTO_WEBSITE_PREVIEW_URL, SITE_URL } from '@/seo/constants';
+import { richTextToPlainText } from '@/seo/articlePlaintext';
+import { jsonLdGraph, sanitizeJsonLdHtml } from '@/seo/jsonLdHtml';
+import { BlogPosting } from 'schema-dts';
 
 type Props = {
   params: Promise<{ slug: string }>
@@ -36,8 +39,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   const isFuture = !isPublishedInEasternTime(post.publishedDate);
-  const fullUrl = `https://www.asianweddingmakeup.com/blog/${post.slug}`;
-  const imageUrl = post.featuredImage?.url || previewImage.src;
+  const fullUrl = `${SITE_URL}/blog/${post.slug}`;
+  const imageUrl = post.featuredImage?.url || PHOTO_WEBSITE_PREVIEW_URL;
 
   return {
     title: `${post.title} | Asian Wedding Makeup`,
@@ -95,52 +98,52 @@ export default async function BlogPostPage({ params }: Props) {
   let jsonLd = {};
 
   if (post) {
-    jsonLd = {
-      "@context": "https://schema.org",
+    const blogPosting: BlogPosting = {
       "@type": "BlogPosting",
       "mainEntityOfPage": {
         "@type": "WebPage",
-        "@id": `https://www.asianweddingmakeup.com/blog/${slug}`
+        "@id": `${SITE_URL}/blog/${slug}`
       },
-      "headline": post.title,
+      "headline": post.title ?? "",
       "description": post.shortDescription ?? "",
-      "url": `https://www.asianweddingmakeup.com/blog/${slug}`,
-      "datePublished": post.publishedDate,
+      "url": `${SITE_URL}/blog/${slug}`,
+      "datePublished": post.publishedDate ?? undefined,
       "author": {
         "@type": "Person",
         "name": post.author?.name ?? "Unknown",
         "image": post.author?.avatar?.url ? `https:${post.author.avatar.url}` : undefined
       },
-      "publisher": {
-        "@type": "Organization",
-        "name": "Asian Wedding Makeup",
-        "logo": {
-          "@type": "ImageObject",
-          "url": previewImage.src
-        }
+      "isPartOf": {
+        "@id": `${SITE_URL}/blog#webpage`
       },
-      "image": post.featuredImage?.url ?? previewImage.src,
-      "articleBody": post.content?.json ? post.content.json : ""
+      "publisher": {
+        "@id": ORG_ID
+      },
+      "image": post.featuredImage?.url ?? PHOTO_WEBSITE_PREVIEW_URL,
+      "articleBody": richTextToPlainText(post.content?.json)
     };
-  }
-  const isSpotlight = post?.contentfulMetadata?.tags?.some(tag => tag?.id === "makeupArtistSpotlight");
-  return (
-    <>
-      <section>
-        {post && (
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-          />
+
+    jsonLd = jsonLdGraph([blogPosting]);
+
+    const isSpotlight = post?.contentfulMetadata?.tags?.some(tag => tag?.id === "makeupArtistSpotlight");
+    return (
+      <>
+        <section>
+          {post && (
+            <script
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{ __html: sanitizeJsonLdHtml(jsonLd) }}
+            />
+          )}
+        </section>
+        <BackButton fallbackHref="/blog" />
+        {isSpotlight ? (
+          <Spotlight post={post} />
+        ) : (
+          <Article post={post} />
         )}
-      </section>
-      <BackButton fallbackHref="/blog" />
-      {isSpotlight ? (
-        <Spotlight post={post} />
-      ) : (
-        <Article post={post} />
-      )}
-      <Scroll showBelow={300} />
-    </>
-  )
+        <Scroll showBelow={300} />
+      </>
+    )
+  }
 }

--- a/frontend/src/app/(public)/blog/page.tsx
+++ b/frontend/src/app/(public)/blog/page.tsx
@@ -1,19 +1,23 @@
 import { ArticleTable } from '@/features/blog/components/ArticleTable';
+import { getAllPosts, getValidPosts, PageBlogPost } from '@/features/blog/api/getBlogPosts';
 import Scroll from '@/components/ui/Scroll';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import { Metadata } from 'next';
+import { CollectionPage } from 'schema-dts';
+import { jsonLdGraph, sanitizeJsonLdHtml } from '@/seo/jsonLdHtml';
+import { ORG_ID, SITE_URL, WEBSITE_ID } from '@/seo/constants';
 
 export const metadata: Metadata = {
   title: 'Wedding Planning Resources for Asian Couples | Asian Wedding Makeup',
   description: 'Tips, guides, and inspiration for Asian couples planning their wedding. From bridal beauty to cultural traditions.',
   alternates: {
-    canonical: '/blog',
+    canonical: `${SITE_URL}/blog`,
   },
   openGraph: {
     title: 'Wedding Planning Resources for Asian Couples | Asian Wedding Makeup',
     description: 'Tips, guides, and inspiration for Asian couples planning their wedding. From bridal beauty to cultural traditions.',
-    url: '/blog',
+    url: `${SITE_URL}/blog`,
     type: 'website',
   },
   robots: {
@@ -23,26 +27,56 @@ export const metadata: Metadata = {
 }
 
 export default async function BlogIndex() {
+  const posts: PageBlogPost[] = await getAllPosts();
+  const validPosts = getValidPosts(posts);
+
+  const collectionPage: CollectionPage = {
+    "@type": "CollectionPage",
+    "@id": `${SITE_URL}/blog#webpage`,
+    "url": `${SITE_URL}/blog`,
+    "name": "Wedding Planning Resources for Asian Couples",
+    "description": "Tips, guides, and inspiration for Asian couples planning their wedding. From bridal beauty to cultural traditions.",
+    "isPartOf": { "@id": WEBSITE_ID },
+    "publisher": { "@id": ORG_ID },
+    "mainEntity": {
+      "@type": "ItemList",
+      "@id": `${SITE_URL}/blog#postlist`,
+      "itemListElement": validPosts
+        .filter((post) => post.title != null && post.slug != null)
+        .map((post, index) => ({
+          "@type": "ListItem" as const,
+          "position": index + 1,
+          "url": `${SITE_URL}/blog/${post.slug}`,
+          "name": post.title ?? undefined,
+        })),
+    },
+  };
+
+  const jsonLd = jsonLdGraph([collectionPage]);
 
   return (
-    <Container maxWidth="lg">
-      <br />
-      <Box
-        sx={{
-          my: 4,
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          textAlign: 'left',
-          '& > p': { marginBottom: 2 },
-        }}
-      >
-        <ArticleTable />
-
-      </Box>
-      <br />
-      <Scroll showBelow={300} />
-    </Container>
-
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: sanitizeJsonLdHtml(jsonLd) }}
+      />
+      <Container maxWidth="lg">
+        <br />
+        <Box
+          sx={{
+            my: 4,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            textAlign: 'left',
+            '& > p': { marginBottom: 2 },
+          }}
+        >
+          <ArticleTable posts={validPosts} />
+        </Box>
+        <br />
+        <Scroll showBelow={300} />
+      </Container>
+    </>
   );
 }

--- a/frontend/src/app/(public)/faq/page.tsx
+++ b/frontend/src/app/(public)/faq/page.tsx
@@ -3,6 +3,10 @@ import Typography from "@mui/material/Typography";
 import { Metadata } from "next";
 import defaultImage from '@/assets/photo_website_preview.jpg';
 import FaqList from "@/components/layouts/FaqList";
+import { SITE_URL } from "@/seo/constants";
+import { FAQPage as FAQPageSchema } from 'schema-dts';
+import { stripMarkdownLinks } from "@/seo/markdownPlaintext";
+import { jsonLdGraph, sanitizeJsonLdHtml } from "@/seo/jsonLdHtml";
 
 const faqs = [
   {
@@ -109,15 +113,40 @@ export const metadata: Metadata = {
   },
 };
 
+
 const FAQPage = () => {
+  const allFaqItems = faqs.flatMap((group) => group.items);
+
+  const faqSchema: FAQPageSchema = {
+    "@type": "FAQPage",
+    "@id": `${SITE_URL}/faq#faq`,
+    "url": `${SITE_URL}/faq`,
+    "mainEntity": allFaqItems.map((item) => ({
+      "@type": "Question",
+      "name": stripMarkdownLinks(item.question),
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": stripMarkdownLinks(item.answer),
+      },
+    })),
+  };
+
+  const jsonLd = jsonLdGraph([faqSchema]);
+
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
-      <br />
-      <Typography variant="h1" gutterBottom>
-        Frequently Asked Questions
-      </Typography>
-      <FaqList faqs={faqs} />  
-    </Container>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: sanitizeJsonLdHtml(jsonLd) }}
+      />
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <br />
+        <Typography variant="h1" gutterBottom>
+          Frequently Asked Questions
+        </Typography>
+        <FaqList faqs={faqs} />
+      </Container>
+    </>
   );
 };
 

--- a/frontend/src/features/blog/api/getBlogPosts.ts
+++ b/frontend/src/features/blog/api/getBlogPosts.ts
@@ -14,15 +14,17 @@ export type SinglePageBlogPost = NonNullable<GetBlogPostBySlugQuery['pageBlogPos
 export type Content = NonNullable<SinglePageBlogPost>['content'];
 
 const _getAllPosts = unstable_cache(
-  async () => {
+  async (): Promise<PageBlogPost[]> => {
     const { pageBlogPostCollection } = await graphQLClient.request<GetAllBlogPostsQuery>(GetAllBlogPostsDocument);
-    return pageBlogPostCollection?.items || [];
+    return (pageBlogPostCollection?.items ?? []).filter(
+      (item): item is PageBlogPost => item !== null
+    );
   },
   ['all-posts'],
   { revalidate: CACHE_TTL, tags: ['all-posts'] }
 )
 
-export async function getAllPosts() {
+export async function getAllPosts(): Promise<PageBlogPost[]> {
   try {
     return await _getAllPosts()
   } catch (err) {

--- a/frontend/src/features/blog/components/ArticleTable.tsx
+++ b/frontend/src/features/blog/components/ArticleTable.tsx
@@ -1,5 +1,5 @@
 import Box from '@mui/material/Box';
-import { getAllPosts, getValidPosts } from '@/features/blog/api/getBlogPosts';
+import { PageBlogPost } from '@/features/blog/api/getBlogPosts';
 import { isDevOrPreview } from '@/lib/env/env';
 import { RefreshButton } from './RefreshButton';
 import { BlogContent } from './BlogContent';
@@ -13,18 +13,19 @@ export interface FilterGroup {
   options: string[];
 }
 
-export async function ArticleTable() {
-  const posts = await getAllPosts();
-  const validPosts = getValidPosts(posts);
+interface ArticleTableProps {
+  posts: PageBlogPost[];
+}
 
-  const featuredIndex = validPosts.findIndex((p) =>
+export function ArticleTable({ posts }: ArticleTableProps) {
+  const featuredIndex = posts.findIndex((p) =>
     p.contentfulMetadata?.tags?.some((t) => t?.id === FEATURED_POST_TAG_ID)
   );
-  const featuredPost = featuredIndex !== -1 ? validPosts[featuredIndex] : (validPosts[0] ?? null);
+  const featuredPost = featuredIndex !== -1 ? posts[featuredIndex] : (posts[0] ?? null);
   const remainingPosts =
     featuredIndex !== -1
-      ? validPosts.filter((_, i) => i !== featuredIndex)
-      : validPosts.slice(1);
+      ? posts.filter((_, i) => i !== featuredIndex)
+      : posts.slice(1);
 
   const categorySet = new Set<string>();
   const cultureSet = new Set<string>();
@@ -35,7 +36,7 @@ export async function ArticleTable() {
     return lower === 'uncategorized' || extra.includes(lower);
   };
 
-  for (const post of validPosts) {
+  for (const post of posts) {
     for (const val of post[FILTER_KEY_CATEGORY] ?? []) {
       if (val && !isExcluded(val)) categorySet.add(val);
     }

--- a/frontend/src/seo/articlePlaintext.test.ts
+++ b/frontend/src/seo/articlePlaintext.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { richTextToPlainText } from './articlePlaintext';
+import { BLOCKS, Document, Text, TopLevelBlock, Paragraph } from '@contentful/rich-text-types';
+
+function makeTextNode(value: string): Text {
+  return {
+    nodeType: 'text',
+    value,
+    marks: [],
+    data: {},
+  };
+}
+
+function makeDoc(text: string): Document {
+  const paragraph: Paragraph = {
+    nodeType: BLOCKS.PARAGRAPH,
+    data: {},
+    content: [makeTextNode(text)],
+  };
+
+  return {
+    nodeType: BLOCKS.DOCUMENT,
+    data: {},
+    content: [paragraph as TopLevelBlock],
+  };
+}
+
+describe('richTextToPlainText', () => {
+  it('returns empty string for null/undefined input', () => {
+    expect(richTextToPlainText(null)).toBe('');
+    expect(richTextToPlainText(undefined)).toBe('');
+  });
+
+  it('extracts plain text from a simple document', () => {
+    expect(richTextToPlainText(makeDoc('Hello world'))).toBe('Hello world');
+  });
+
+  it('truncates to maxLength', () => {
+    const longText = 'a'.repeat(1000);
+    expect(richTextToPlainText(makeDoc(longText), 50)).toHaveLength(50);
+  });
+
+  it('collapses extra whitespace', () => {
+    expect(richTextToPlainText(makeDoc('  Hello   world  '))).toBe('Hello world');
+  });
+});

--- a/frontend/src/seo/articlePlaintext.ts
+++ b/frontend/src/seo/articlePlaintext.ts
@@ -1,0 +1,18 @@
+import { documentToPlainTextString } from '@contentful/rich-text-plain-text-renderer';
+import { Document } from '@contentful/rich-text-types';
+
+const DEFAULT_MAX_LENGTH = 500;
+
+/**
+ * Converts a Contentful rich-text document into a plain-text summary,
+ * truncated to a specified maximum length. It also collapses multiple whitespace characters into a single space.
+ */
+export function richTextToPlainText(
+  doc: Document | null | undefined,
+  maxLength: number = DEFAULT_MAX_LENGTH
+): string {
+  if (!doc) return '';
+
+  const text = documentToPlainTextString(doc).trim().replace(/\s+/g, ' ');
+  return text.slice(0, maxLength);
+}

--- a/frontend/src/seo/markdownPlaintext.ts
+++ b/frontend/src/seo/markdownPlaintext.ts
@@ -1,0 +1,8 @@
+/**
+ * Converts `[text](url)` markdown links to plain "text" for JSON-LD fields,
+ * which expect plain text, not markdown. Keeps the link's visible text,
+ * drops the URL and brackets.
+ */
+export function stripMarkdownLinks(text: string): string {
+  return text.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+}


### PR DESCRIPTION
- use new utils on the existing json-ld for the individual blog article pages
- add json-ld schemas for `/blog` and `/faq` page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enhanced SEO metadata and structured data for blog posts, blog listings, and FAQs.
  - Added rich-text and Markdown conversion for cleaner search previews and structured content.
  - Added reliable canonical and social-sharing URLs with improved fallback imagery.
- **Bug Fixes**
  - Improved blog post loading and filtering to prevent invalid entries from affecting page displays.
  - Updated article listings to render consistently from validated post data.
- **Tests**
  - Added coverage for rich-text conversion, truncation, whitespace handling, and missing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->