### PR TITLE
improve page loading speed by lazy loading recaptcha and setting image priority

### DIFF
--- a/frontend/src/components/layouts/PhotoCarousel.tsx
+++ b/frontend/src/components/layouts/PhotoCarousel.tsx
@@ -43,7 +43,8 @@ export const PhotoCarousel = ({ photos, vendorSlug, placeholderImage }: {
                 objectFit: 'cover',
               }}
               quality={85}
-              priority={index < 3}
+              loading={index === 0 ? "eager" : "lazy"}
+              fetchPriority={index === 0 ? "high" : "auto"}
             />
           </Box>
         </Box>

--- a/frontend/src/components/ui/ContentfulImage.tsx
+++ b/frontend/src/components/ui/ContentfulImage.tsx
@@ -14,7 +14,7 @@ export default function ContentfulImage(
       fill?: boolean;
       loader?: import("next/dist/shared/lib/get-img-props").ImageLoader;
       quality?: number | `${number}`;
-      priority?: boolean;
+      fetchPriority?: "high" | "low" | "auto";
       loading?: "eager" | "lazy" | undefined;
       placeholder?: PlaceholderValue;
       blurDataURL?: string;

--- a/frontend/src/features/blog/components/FeaturedPost.tsx
+++ b/frontend/src/features/blog/components/FeaturedPost.tsx
@@ -54,7 +54,8 @@ export function FeaturedPost({ post }: FeaturedPostProps) {
               alt={post.featuredImage.description ?? `Cover image for ${post.title}`}
               src={post.featuredImage.url}
               fill
-              priority
+              loading="eager"
+              fetchPriority="high"
               sizes={isLandscape ? '(max-width: 900px) 100vw, 55vw' : '(max-width: 900px) 40vw, 45vw'}
               style={{ objectFit: 'cover', objectPosition: isLandscape ? 'center' : 'center top' }}
             />

--- a/frontend/src/features/blog/components/PostHeader.tsx
+++ b/frontend/src/features/blog/components/PostHeader.tsx
@@ -20,7 +20,8 @@ const PostHeader = ({ post }: { post: PageBlogPost }) => {
               alt={`Cover Image: ${post.featuredImage.title}`}
               src={post.featuredImage.url}
               fill
-              priority
+              loading="eager"
+              fetchPriority="high"
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 800px"
               style={{
                 objectPosition: 'center',

--- a/frontend/src/features/blog/components/SpotlightHeader.tsx
+++ b/frontend/src/features/blog/components/SpotlightHeader.tsx
@@ -42,7 +42,8 @@ const SpotlightHeader = ({ post }: { post: PageBlogPost }) => {
               alt={`Cover Image: ${post.featuredImage.title}`}
               src={post.featuredImage.url}
               fill
-              priority
+              loading="eager"
+              fetchPriority="high"
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 800px"
               style={{
                 objectPosition: 'center top',

--- a/frontend/src/features/contact/components/NewsletterForm.tsx
+++ b/frontend/src/features/contact/components/NewsletterForm.tsx
@@ -19,12 +19,23 @@ export function NewsletterForm() {
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [recaptchaLoaded, setRecaptchaLoaded] = useState(false);
   const recaptchaRef = useRef<ReCaptchaRef>(null);
 
   const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault();
     setError("");
     setSubmitted(false);
+
+    // reCAPTCHA is lazy-mounted (see recaptchaLoaded below) — if it somehow
+    // hasn't finished loading by submit time (e.g. instant autofill + submit),
+    // mount it now and bail so the user can resubmit once it's ready.
+    if (!recaptchaRef.current) {
+      setRecaptchaLoaded(true);
+      setError("Please try submitting again.");
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -32,7 +43,7 @@ export function NewsletterForm() {
         (await recaptchaRef.current?.executeAsync()) ??
         (isDevOrPreview() ? "test-bypass" : null);
 
-      if (!recaptchaToken) {
+        if (!recaptchaToken) {
         setError("CAPTCHA verification failed. Please try again.");
         return;
       }
@@ -89,43 +100,30 @@ export function NewsletterForm() {
                 type="email"
                 value={formData.email}
                 onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                onFocus={() => setRecaptchaLoaded(true)}
                 required
                 fullWidth
               />
-              <ReCaptcha
-                ref={recaptchaRef}
-                size="invisible"
-                onExpired={() => console.warn("reCAPTCHA expired")}
-                onErrored={() => console.warn("reCAPTCHA errored")}
-              />
+              {recaptchaLoaded && (
+                <ReCaptcha
+                  ref={recaptchaRef}
+                  size="invisible"
+                  onExpired={() => console.warn("reCAPTCHA expired")}
+                  onErrored={() => console.warn("reCAPTCHA errored")}
+                />
+              )}
               <Button
                 type="submit"
                 variant="contained"
                 color="primary"
                 sx={{ flexShrink: 0 }}
                 disabled={isSubmitting}
+                onMouseEnter={() => setRecaptchaLoaded(true)}
+                onTouchStart={() => setRecaptchaLoaded(true)}
               >
                 Sign up
               </Button>
             </Box>
-
-            {/* <Typography variant="subtitle1">I am interested in...</Typography> */}
-            {/* <FormGroup sx={{ display: "flex", alignItems: "left" }}>
-              {reasons.map((option) => (
-                <FormControlLabel
-                  key={option.value}
-                  control={
-                    <Checkbox
-                      checked={formData.reasons.includes(option.value)}
-                      onChange={() => handleCheckboxChange(option.value)}
-                    />
-                  }
-                  label={option.label}
-                />
-              ))}
-            </FormGroup> */}
-
-
           </Box>
         )}
       </Container>

--- a/frontend/src/features/contact/components/NewsletterForm.tsx
+++ b/frontend/src/features/contact/components/NewsletterForm.tsx
@@ -118,6 +118,7 @@ export function NewsletterForm() {
                 color="primary"
                 sx={{ flexShrink: 0 }}
                 disabled={isSubmitting}
+                onFocus={() => setRecaptchaLoaded(true)}
                 onMouseEnter={() => setRecaptchaLoaded(true)}
                 onTouchStart={() => setRecaptchaLoaded(true)}
               >

--- a/frontend/src/features/contact/components/NewsletterForm.tsx
+++ b/frontend/src/features/contact/components/NewsletterForm.tsx
@@ -29,7 +29,7 @@ export function NewsletterForm() {
 
     // reCAPTCHA is lazy-mounted (see recaptchaLoaded below) — if it somehow
     // hasn't finished loading by submit time (e.g. instant autofill + submit),
-    // mount it now and bail so the user can resubmit once it's ready.
+    // mount it now and bail so the user can resubmit once it's ready
     if (!recaptchaRef.current) {
       setRecaptchaLoaded(true);
       setError("Please try submitting again.");
@@ -43,7 +43,7 @@ export function NewsletterForm() {
         (await recaptchaRef.current?.executeAsync()) ??
         (isDevOrPreview() ? "test-bypass" : null);
 
-        if (!recaptchaToken) {
+      if (!recaptchaToken) {
         setError("CAPTCHA verification failed. Please try again.");
         return;
       }

--- a/frontend/src/features/directory/components/VendorCard.tsx
+++ b/frontend/src/features/directory/components/VendorCard.tsx
@@ -163,6 +163,7 @@ export const VendorCard = ({
                 <VendorCardImage
                   key={index}
                   cardPosition={positionIndex}
+                  imageIndex={index}
                   vendorImage={image}
                   vendorBusinessName={vendor.business_name}
                   placeholderImage={placeholderImage}

--- a/frontend/src/features/directory/components/VendorCardImage.tsx
+++ b/frontend/src/features/directory/components/VendorCardImage.tsx
@@ -5,16 +5,26 @@ import { VendorMedia } from '@/types/vendorMedia';
 export default function VendorCardImage({
   vendorImage,
   cardPosition,
+  imageIndex = 0, // defaults to 0 for non-carousel single-image usage
   vendorBusinessName,
   placeholderImage,
   variant
 }: {
   vendorImage: Partial<VendorMedia> | null | undefined;
   cardPosition?: number;
+  imageIndex?: number;
   vendorBusinessName: string | null;
   placeholderImage: StaticImageData;
   variant?: 'default' | 'compact';
 }) {
+
+  const eagerThreshold = variant === 'compact' ? 1 : 3;
+  // Only the first slide of an above-the-fold card should skip lazy-loading.
+  // Later slides in the same card's swiper are only seen after a swipe
+  const isAboveTheFold =
+    imageIndex === 0 && cardPosition !== undefined && cardPosition < eagerThreshold;
+  const isLikelyLCP = imageIndex === 0 && cardPosition === 0;
+
   return (
     <Box
       sx={{
@@ -29,13 +39,14 @@ export default function VendorCardImage({
         src={vendorImage?.media_url ?? placeholderImage}
         alt={`${vendorBusinessName ?? ''} preview`}
         fill
-        sizes="(max-width: 600px) 100vw, 400px"
+        sizes={variant === 'compact' ? '240px' : '(max-width: 600px) 100vw, 400px'}
         style={{
           objectFit: 'cover',
           objectPosition: 'center'
         }}
         quality={75}
-        priority={cardPosition ? cardPosition < 3 : false}
+        loading={isAboveTheFold ? 'eager' : 'lazy'}
+        fetchPriority={isLikelyLCP ? 'high' : 'auto'}
       />
     </Box>
   );

--- a/frontend/src/features/profile/common/components/VendorCoverImage.tsx
+++ b/frontend/src/features/profile/common/components/VendorCoverImage.tsx
@@ -35,7 +35,8 @@ export function VendorCoverImage({
           sizes="(max-width: 768px) 100vw, 600px"
           style={{ objectFit: 'cover' }}
           quality={80}
-          priority={true}
+          loading="eager"
+          fetchPriority="high"
         />
         {coverImage.credits && (
           <Box


### PR DESCRIPTION
* **Improvements**
  * Analytics show reCAPTCHA script is expensive to load. It's currently loaded on all our public page because our newsletter form in the footer uses it. I changed it to be lazy-loaded when the user interacts with the form
  * Analytics show our featured image loading is affecting page load. Next.js 16 is supposed to use `loading` and `fetchPriority` but we were using the deprecated `priority`. I added the new priority props to blog images, profile images, and the vendor directory
