### PR TITLE
Fix refreshing blogs on landing page

### DIFF
--- a/frontend/src/features/landingPage/components/BlogCarouselData.tsx
+++ b/frontend/src/features/landingPage/components/BlogCarouselData.tsx
@@ -14,7 +14,8 @@ export async function BlogCarouselData() {
       if (!post || !post.slug || selectedSlugs.has(post.slug)) return false;
       selectedSlugs.add(post.slug);
       return true;
-    });
+    })
+    .sort((a, b) => new Date(b.publishedDate!).getTime() - new Date(a.publishedDate!).getTime());
   if (recentPosts.length === 0) return null;
 
   return <BlogPostCarousel posts={recentPosts} />;

--- a/frontend/src/features/landingPage/components/BlogSection.tsx
+++ b/frontend/src/features/landingPage/components/BlogSection.tsx
@@ -7,7 +7,7 @@ import { Suspense } from 'react';
 import { BlogCarouselSkeleton } from './BlogCarouselSkeleton';
 import { BlogCarouselData } from './BlogCarouselData';
 
-export const FEATURED_CATEGORIES = ['vendor-spotlight', 'cultural-history', 'vendor-list'] as const;
+export const FEATURED_CATEGORIES = ['vendor-spotlight', 'cultural-history', 'vendor-list', 'editorial', 'wedding-inspo'] as const;
 
 export async function BlogSection() {
 

--- a/frontend/src/lib/actions/revalidate.ts
+++ b/frontend/src/lib/actions/revalidate.ts
@@ -14,6 +14,7 @@ export async function revalidateVendors() {
 
 export async function revalidateBlog() {
   revalidateTag('all-posts', { expire: 0 })
+  revalidatePath('/')             // refreshes the blog carousel on the landing page
   revalidatePath('/blog')         // refreshes the article table
   revalidatePath('/blog/[slug]', 'page')  // refreshes all post pages
 }


### PR DESCRIPTION
**Root cause:** the landing page (/) is a fully static route — no revalidate/dynamic config — so its HTML/RSC payload sits in Next's full route cache until something explicitly
  revalidates that path. The Contentful revalidation hook (src/lib/actions/revalidate.ts:15) busted the all-posts data cache and revalidated /blog and /blog/[slug], but never /. So
  /blog picked up new posts (your second screenshot) while the landing carousel stayed frozen at whatever was rendered on the last deploy.

  One thing worth flagging, separate from the caching bug: BlogCarouselData picks the newest post from each of FEATURED_CATEGORIES (vendor-spotlight, cultural-history, vendor-list) — so
  posts in other categories (e.g. the Aug 7 "Best Sunscreen" editorial, the July 22 wedding-inspo guide) will still never appear on the landing page even after this fix.