### PR TITLE
keep url param fix while making vendors page static again

### DIFF
--- a/frontend/src/app/(public)/[slug]/page.tsx
+++ b/frontend/src/app/(public)/[slug]/page.tsx
@@ -20,8 +20,6 @@ interface LocationPageProps {
   params: Promise<{ slug: string }>;
 }
 
-export const dynamic = 'force-dynamic';
-
 // Page component
 export default async function LocationPage({ params }: LocationPageProps) {
   const { slug } = await params;

--- a/frontend/src/app/(public)/vendors/page.tsx
+++ b/frontend/src/app/(public)/vendors/page.tsx
@@ -6,8 +6,6 @@ import { jsonLdGraph, sanitizeJsonLdHtml } from '@/seo/jsonLdHtml';
 import { ORG_ID, SITE_URL, WEBSITE_ID, PHOTO_WEBSITE_PREVIEW_URL } from '@/seo/constants';
 import { getDefaultBio } from '@/features/profile/common/utils/bio';
 
-export const dynamic = 'force-dynamic';
-
 export const metadata: Metadata = {
   title: 'Directory | Asian Wedding Makeup Artists in NYC, Toronto & More',
   description: 'Browse our curated directory of wedding makeup artists experienced with Asian features. Search by price, skill, and location.',

--- a/frontend/src/hooks/useURLFilters.ts
+++ b/frontend/src/hooks/useURLFilters.ts
@@ -1,8 +1,7 @@
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 export function useURLFilters() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname() || ''; // SSR-safe
 
@@ -30,6 +29,18 @@ export function useURLFilters() {
     [searchParams]
   );
 
+  // Shared helper: update the URL via the native History API instead of
+  // router.push/replace. Next.js patches window.history so useSearchParams()
+  // still picks this up reactively, but it skips the App Router's
+  // navigation pipeline entirely — which is what was silently no-op'ing on
+  // search-param-only navigations on statically rendered routes.
+  const pushUrl = useCallback((newParams: URLSearchParams) => {
+    const search = newParams.toString();
+    const targetPath = pathnameRef.current;
+    const newUrl = search ? `${targetPath}?${search}` : targetPath;
+    window.history.pushState(null, '', newUrl);
+  }, []);
+
   const setParams = useCallback(
     (updates: Record<string, string | null>) => {
       const currentParams = searchParamsRef.current?.toString() ?? "";
@@ -41,14 +52,9 @@ export function useURLFilters() {
           newParams.set(key, value);
         }
       });
-      const search = newParams.toString();
-      // Always stay on the current page (e.g. /vendors or a /[location] page)
-      // so applying a filter never bounces the user to a different route.
-      const targetPath = pathnameRef.current;
-      const newUrl = search ? `${targetPath}?${search}` : targetPath;
-      router.push(newUrl, { scroll: false });
+      pushUrl(newParams);
     },
-    [router]
+    [pushUrl]
   );
 
   const setParam = useCallback(
@@ -66,12 +72,9 @@ export function useURLFilters() {
       if (values && values.length > 0) {
         values.forEach(value => newParams.append(key, value));
       }
-      const search = newParams.toString();
-      const targetPath = pathnameRef.current;
-      const newUrl = search ? `${targetPath}?${search}` : targetPath;
-      router.push(newUrl, { scroll: false });
+      pushUrl(newParams);
     },
-    [router]
+    [pushUrl]
   );
 
   return {


### PR DESCRIPTION
## Summary

I made the `/vendors` and `/[location]` pages dynamic (`force-dynamic`) to fix a bug where filters weren't clearable (#295, #296). However, this made performance slower — every request lost Full Route Cache / CDN caching and hit the server on every request, since `force-dynamic` opts the whole route out of static rendering.

This preserves the fix while restoring static rendering, by fixing the actual root cause instead of routing around it.

## Root cause

`router.push`/`router.replace` from `next/navigation` silently no-ops on statically-rendered routes when only the search string changes — Next's client router assumes a static segment's output can't differ and skips the navigation. That's why removing a filter chip did nothing in production/preview but worked in `next dev`.

`force-dynamic` fixed it as a side effect (dynamic routes don't get this optimization), but at the cost of static caching for the whole page.

## Fix

- `useURLFilters` now updates the URL via the native History API (`window.history.pushState`) instead of `router.push`. Next.js patches `window.history` so `useSearchParams()` still picks up the change reactively, but the update never goes through the App Router's navigation pipeline — so it can't hit the static-segment skip, and it never round-trips to the server (filtering is entirely client-side already).
- Reverted `dynamic = 'force-dynamic'` on `/vendors/page.tsx` and `/[location]/page.tsx`. Neither page reads `searchParams` server-side, so there's no reason for them to be dynamic — they're back to static/ISR.
